### PR TITLE
Make trained PerTurbo model loadable

### DIFF
--- a/.github/workflows/sync.yaml
+++ b/.github/workflows/sync.yaml
@@ -1,10 +1,5 @@
 name: Sync Template
 
-on:
-  workflow_dispatch:
-  schedule:
-    - cron: "0 2 * * *" # every night at 2:00 UTC
-
 jobs:
   sync:
     runs-on: ubuntu-latest

--- a/reproducibility/STINGseq-v1.ipynb
+++ b/reproducibility/STINGseq-v1.ipynb
@@ -1,0 +1,479 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "ccb12167-057f-418d-bef8-257ed16c2634",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import anndata as ad\n",
+    "import scanpy as sc\n",
+    "import mudata as md\n",
+    "import pandas as pd\n",
+    "data_dir=\"data/SHARED_DATA/STINGseq\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a3d75cf1-b9c5-4069-b978-0a2eb76b5136",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "metadata = pd.read_excel(f\"{data_dir}/science.adh7699_table_s3.xlsx\", sheet_name=\"Table S3C\", skiprows=2)\n",
+    "metadata = (\n",
+    "    metadata\n",
+    "    .assign(barcode=lambda x: x['Cell Barcode']+\"-1\")\n",
+    "    .set_index(\"barcode\")\n",
+    ")\n",
+    "metadata"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 256,
+   "id": "56ea2cb3-5541-4ba6-b17b-4a8dca5bb8a0",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Read and combine the STINGseq anndatas (genes + guides)\n",
+    "# stingseq_gdo_files = [f for f in os.listdir(data_dir) if re.search(\"GSM[0-9]+.*STINGseq.*_GDO\", f)]\n",
+    "prefixes = {\n",
+    "    # 'GSM5225859_STINGseq-v1_GDO.':'',\n",
+    "    # 'GSM7108121_STINGseq-v2_GDO-A_':'A_',\n",
+    "    # 'GSM7108122_STINGseq-v2_GDO-B_':'B_',\n",
+    "    'GSM7108123_STINGseq-v2_GDO-C_':'C_',\n",
+    "    'GSM7108124_STINGseq-v2_GDO-D_':'D_',\n",
+    "}\n",
+    "\n",
+    "prefixes = {\n",
+    "    'GSM7108136_BeeSTINGseq_GDO-A_':'A_',\n",
+    "    'GSM7108137_BeeSTINGseq_GDO-B_':'B_',\n",
+    "    'GSM7108138_BeeSTINGseq_GDO-C_':'C_',\n",
+    "}\n",
+    "\n",
+    "adatas = []\n",
+    "for file_prefix, bc_prefix in prefixes.items():\n",
+    "    print(f\"{file_prefix[:-1]}\")\n",
+    "    adata = sc.read_10x_mtx(data_dir, prefix=file_prefix, gex_only=False)\n",
+    "    adata.obs.index = bc_prefix+adata.obs.index\n",
+    "    adatas.append(adata)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 268,
+   "id": "a14f694d-7697-4ef1-8e0e-8342b1d84cf7",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>gene_ids</th>\n",
+       "      <th>feature_types</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>MIR1302-2HG</th>\n",
+       "      <td>ENSG00000243485</td>\n",
+       "      <td>Gene Expression</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>FAM138A</th>\n",
+       "      <td>ENSG00000237613</td>\n",
+       "      <td>Gene Expression</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>OR4F5</th>\n",
+       "      <td>ENSG00000186092</td>\n",
+       "      <td>Gene Expression</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>AL627309.1</th>\n",
+       "      <td>ENSG00000238009</td>\n",
+       "      <td>Gene Expression</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>AL627309.3</th>\n",
+       "      <td>ENSG00000239945</td>\n",
+       "      <td>Gene Expression</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>NTC-GV2-26</th>\n",
+       "      <td>NTC-GV2-26</td>\n",
+       "      <td>CRISPR Guide Capture</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>NTC-GV2-27</th>\n",
+       "      <td>NTC-GV2-27</td>\n",
+       "      <td>CRISPR Guide Capture</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>NTC-GV2-28</th>\n",
+       "      <td>NTC-GV2-28</td>\n",
+       "      <td>CRISPR Guide Capture</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>NTC-GV2-29</th>\n",
+       "      <td>NTC-GV2-29</td>\n",
+       "      <td>CRISPR Guide Capture</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>NTC-GV2-30</th>\n",
+       "      <td>NTC-GV2-30</td>\n",
+       "      <td>CRISPR Guide Capture</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>36939 rows × 2 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                    gene_ids         feature_types\n",
+       "MIR1302-2HG  ENSG00000243485       Gene Expression\n",
+       "FAM138A      ENSG00000237613       Gene Expression\n",
+       "OR4F5        ENSG00000186092       Gene Expression\n",
+       "AL627309.1   ENSG00000238009       Gene Expression\n",
+       "AL627309.3   ENSG00000239945       Gene Expression\n",
+       "...                      ...                   ...\n",
+       "NTC-GV2-26        NTC-GV2-26  CRISPR Guide Capture\n",
+       "NTC-GV2-27        NTC-GV2-27  CRISPR Guide Capture\n",
+       "NTC-GV2-28        NTC-GV2-28  CRISPR Guide Capture\n",
+       "NTC-GV2-29        NTC-GV2-29  CRISPR Guide Capture\n",
+       "NTC-GV2-30        NTC-GV2-30  CRISPR Guide Capture\n",
+       "\n",
+       "[36939 rows x 2 columns]"
+      ]
+     },
+     "execution_count": 268,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "adata=ad.concat(adatas, merge=\"unique\")\n",
+    "gex_idx = adata.var['feature_types']=\"unique\"\n",
+    "adata.var\n",
+    "# adata.write(\"BeeSTINGseq_raw.h5ad\")\n",
+    "\n",
+    "# adata\n",
+    "# for cdna_prefix, gdo_prefix, hto_prefix in zip(cdna_prefixes,gdo_prefixes,hto_prefixes): \n",
+    "#     print(gdo_prefix)\n",
+    "#     gdo_adata = sc.read_10x_mtx(data_dir, prefix=\"GSM5225859_STINGseq-v1_GDO.\", gex_only=False)\n",
+    "#     gdo_adata = gdo_adata[:,gdo_adata.var['feature_types']==\"CRISPR Guide Capture\"]\n",
+    "#     mdata = md.MuData({\"cdna\": cdna_adata, \"hto\": hto_adata, \"gdo\": gdo_adata})\n",
+    "    \n",
+    "\n",
+    "# for prefix in prefixes:\n",
+    "#     is_cdna = (\"cDNA\" in prefix)\n",
+    "#     adata = sc.read_10x_mtx(data_dir, prefix=prefix, gex_only=is_cdna)\n",
+    "#     if \"GDO\" in \n",
+    "        "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 260,
+   "id": "8d6d147c-8dd5-4928-a54a-f52baaaac6f5",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "AnnData object with n_obs × n_vars = 39049 × 36939"
+      ]
+     },
+     "execution_count": 260,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "adata"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 245,
+   "id": "d01a7b9b-ed5d-4264-95c6-8f89b5ae9dcd",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<pre>MuData object with n_obs × n_vars = 38916 × 38296\n",
+       "  obs:\t&#x27;Library&#x27;, &#x27;Lane Batch&#x27;, &#x27;Cell Barcode&#x27;, &#x27;Total Gene Expression UMIs&#x27;, &#x27;Unique Genes&#x27;, &#x27;Mitochondrial Percentage&#x27;, &#x27;Total gRNA Expression UMIs&#x27;, &#x27;Unique gRNAs (after adaptive thresholding)&#x27;, &#x27;Total ADT UMIs&#x27;, &#x27;Total HTO UMIs&#x27;, &#x27;ADT CTL1&#x27;, &#x27;ADT CTL2&#x27;, &#x27;ADT CTL3&#x27;, &#x27;ADT CTL4&#x27;\n",
+       "  var:\t&#x27;gene_ids&#x27;, &#x27;feature_types&#x27;\n",
+       "  2 modalities\n",
+       "    cdna:\t38916 x 36601\n",
+       "      var:\t&#x27;gene_ids&#x27;, &#x27;feature_types&#x27;\n",
+       "    gdo:\t38916 x 1695\n",
+       "      var:\t&#x27;gene_ids&#x27;, &#x27;feature_types&#x27;</pre>"
+      ],
+      "text/plain": [
+       "MuData object with n_obs × n_vars = 38916 × 38296\n",
+       "  obs:\t'Library', 'Lane Batch', 'Cell Barcode', 'Total Gene Expression UMIs', 'Unique Genes', 'Mitochondrial Percentage', 'Total gRNA Expression UMIs', 'Unique gRNAs (after adaptive thresholding)', 'Total ADT UMIs', 'Total HTO UMIs', 'ADT CTL1', 'ADT CTL2', 'ADT CTL3', 'ADT CTL4'\n",
+       "  var:\t'gene_ids', 'feature_types'\n",
+       "  2 modalities\n",
+       "    cdna:\t38916 x 36601\n",
+       "      var:\t'gene_ids', 'feature_types'\n",
+       "    gdo:\t38916 x 1695\n",
+       "      var:\t'gene_ids', 'feature_types'"
+      ]
+     },
+     "execution_count": 245,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "mdata_A = md.read(\"adata/GSM7108121_STINGseq-v2_GDO-A.h5mu\")\n",
+    "mdata_B = md.read(\"adata/GSM7108122_STINGseq-v2_GDO-B.h5mu\")\n",
+    "mdata_C = md.read(\"adata/GSM7108123_STINGseq-v2_GDO-C.h5mu\")\n",
+    "mdata_D = md.read(\"adata/GSM7108124_STINGseq-v2_GDO-D.h5mu\")\n",
+    "mdatas = {\n",
+    "    'A':mdata_A,\n",
+    "    'B':mdata_B,\n",
+    "    'C':mdata_C,\n",
+    "    'D':mdata_D,\n",
+    "}\n",
+    "for lane, mdata in mdatas.items():\n",
+    "    mdata.mod['cdna'].obs.index = lane+'_'+mdata.mod['cdna'].obs.index\n",
+    "    mdata.mod['gdo'].obs.index = lane+'_'+mdata.mod['gdo'].obs.index\n",
+    "    mdata.update()\n",
+    "\n",
+    "cdna_adata = ad.concat([m.mod['cdna'] for m in mdatas.values()])\n",
+    "gdo_adata = ad.concat([m.mod['gdo'] for m in mdatas.values()])\n",
+    "assert (mdata_A.var_names == mdata.var_names).all()\n",
+    "cdna_adata.var = mdata_A['cdna'].var\n",
+    "gdo_adata.var = mdata_A['gdo'].var\n",
+    "mdata = md.MuData({'cdna':cdna_adata, 'gdo':gdo_adata})\n",
+    "mdata = mdata[v2_metadata.index]\n",
+    "mdata.obs = v2_metadata\n",
+    "mdata.update()\n",
+    "# mdata.write('STINGseq.h5mu')\n",
+    "mdata"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 195,
+   "id": "9a82b54d-980b-4f62-95d0-b4f5e2f69338",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Index(['AAACCTGAGAAACCTA-1', 'AAACCTGAGAGTACCG-1', 'AAACCTGAGATGTAAC-1',\n",
+       "       'AAACCTGAGCACGCCT-1', 'AAACCTGAGCCACGCT-1', 'AAACCTGAGGGCTTGA-1',\n",
+       "       'AAACCTGAGGTACTCT-1', 'AAACCTGAGTAGGTGC-1', 'AAACCTGAGTTAAGTG-1',\n",
+       "       'AAACCTGCAAAGCGGT-1',\n",
+       "       ...\n",
+       "       'TTTGTCATCACAGTAC-1', 'TTTGTCATCAGCAACT-1', 'TTTGTCATCCCTTGCA-1',\n",
+       "       'TTTGTCATCCTACAGA-1', 'TTTGTCATCGCCATAA-1', 'TTTGTCATCGCCTGTT-1',\n",
+       "       'TTTGTCATCGTAGGTT-1', 'TTTGTCATCGTCGTTC-1', 'TTTGTCATCTAACGGT-1',\n",
+       "       'TTTGTCATCTCACATT-1'],\n",
+       "      dtype='object', length=79126)"
+      ]
+     },
+     "execution_count": 195,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cdna_adata.obs_names"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 246,
+   "id": "a5f2712d-624d-42d9-91b7-f9145d30b6f6",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "reading cDNA\n",
+      "WARNING: Your filename has more than two extensions: ['.matrix', '.mtx', '.gz'].\n",
+      "Only considering the two last: ['.mtx', '.gz'].\n",
+      "WARNING: Your filename has more than two extensions: ['.matrix', '.mtx', '.gz'].\n",
+      "Only considering the two last: ['.mtx', '.gz'].\n",
+      "reading GDO\n",
+      "WARNING: Your filename has more than two extensions: ['.matrix', '.mtx', '.gz'].\n",
+      "Only considering the two last: ['.mtx', '.gz'].\n",
+      "WARNING: Your filename has more than two extensions: ['.matrix', '.mtx', '.gz'].\n",
+      "Only considering the two last: ['.mtx', '.gz'].\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"reading cDNA\")\n",
+    "cdna_adata_v1 = sc.read_10x_mtx(data_dir, prefix=\"GSM5225857_STINGseq-v1_cDNA.\", gex_only=True)\n",
+    "# print(\"reading HTO\")\n",
+    "# hto_adata = sc.read_10x_mtx(data_dir, prefix=\"GSM5225858_STINGseq-v1_HTO.\", gex_only=False)\n",
+    "print(\"reading GDO\")\n",
+    "gdo_adata_v1 = sc.read_10x_mtx(data_dir, prefix=\"GSM5225859_STINGseq-v1_GDO.\", gex_only=False)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 247,
+   "id": "538c9e36-de03-45cc-8783-21795b0822e1",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "ename": "IndexError",
+     "evalue": "Boolean index does not match AnnData’s shape along this dimension. Boolean index has shape (1695,) while AnnData index has shape (36811,).",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mIndexError\u001b[0m                                Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[247], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m gdo_adata_v1 \u001b[38;5;241m=\u001b[39m \u001b[43mgdo_adata_v1\u001b[49m\u001b[43m[\u001b[49m\u001b[43m:\u001b[49m\u001b[43m,\u001b[49m\u001b[43mgdo_adata\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mvar\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mfeature_types\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m]\u001b[49m\u001b[38;5;241;43m==\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mCRISPR Guide Capture\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m]\u001b[49m\n\u001b[1;32m      2\u001b[0m mdata_v1 \u001b[38;5;241m=\u001b[39m md\u001b[38;5;241m.\u001b[39mMuData({\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mcdna\u001b[39m\u001b[38;5;124m\"\u001b[39m: cdna_adata_filt, \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mhto\u001b[39m\u001b[38;5;124m\"\u001b[39m: hto_adata_filt, \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mgdo\u001b[39m\u001b[38;5;124m\"\u001b[39m: gdo_adata_filt})\n\u001b[1;32m      3\u001b[0m mdata_v1 \u001b[38;5;241m=\u001b[39m mdata_v1[metadata_v1\u001b[38;5;241m.\u001b[39mindex]\n",
+      "File \u001b[0;32m/usr/local/lib/python3.10/dist-packages/anndata/_core/anndata.py:1100\u001b[0m, in \u001b[0;36mAnnData.__getitem__\u001b[0;34m(self, index)\u001b[0m\n\u001b[1;32m   1098\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21m__getitem__\u001b[39m(\u001b[38;5;28mself\u001b[39m, index: Index) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mAnnData\u001b[39m\u001b[38;5;124m\"\u001b[39m:\n\u001b[1;32m   1099\u001b[0m \u001b[38;5;250m    \u001b[39m\u001b[38;5;124;03m\"\"\"Returns a sliced view of the object.\"\"\"\u001b[39;00m\n\u001b[0;32m-> 1100\u001b[0m     oidx, vidx \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_normalize_indices\u001b[49m\u001b[43m(\u001b[49m\u001b[43mindex\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m   1101\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m AnnData(\u001b[38;5;28mself\u001b[39m, oidx\u001b[38;5;241m=\u001b[39moidx, vidx\u001b[38;5;241m=\u001b[39mvidx, asview\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mTrue\u001b[39;00m)\n",
+      "File \u001b[0;32m/usr/local/lib/python3.10/dist-packages/anndata/_core/anndata.py:1081\u001b[0m, in \u001b[0;36mAnnData._normalize_indices\u001b[0;34m(self, index)\u001b[0m\n\u001b[1;32m   1080\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21m_normalize_indices\u001b[39m(\u001b[38;5;28mself\u001b[39m, index: Optional[Index]) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m Tuple[\u001b[38;5;28mslice\u001b[39m, \u001b[38;5;28mslice\u001b[39m]:\n\u001b[0;32m-> 1081\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43m_normalize_indices\u001b[49m\u001b[43m(\u001b[49m\u001b[43mindex\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mobs_names\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mvar_names\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m/usr/local/lib/python3.10/dist-packages/anndata/_core/index.py:33\u001b[0m, in \u001b[0;36m_normalize_indices\u001b[0;34m(index, names0, names1)\u001b[0m\n\u001b[1;32m     31\u001b[0m ax0, ax1 \u001b[38;5;241m=\u001b[39m unpack_index(index)\n\u001b[1;32m     32\u001b[0m ax0 \u001b[38;5;241m=\u001b[39m _normalize_index(ax0, names0)\n\u001b[0;32m---> 33\u001b[0m ax1 \u001b[38;5;241m=\u001b[39m \u001b[43m_normalize_index\u001b[49m\u001b[43m(\u001b[49m\u001b[43max1\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mnames1\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     34\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m ax0, ax1\n",
+      "File \u001b[0;32m/usr/local/lib/python3.10/dist-packages/anndata/_core/index.py:87\u001b[0m, in \u001b[0;36m_normalize_index\u001b[0;34m(indexer, index)\u001b[0m\n\u001b[1;32m     85\u001b[0m \u001b[38;5;28;01melif\u001b[39;00m \u001b[38;5;28missubclass\u001b[39m(indexer\u001b[38;5;241m.\u001b[39mdtype\u001b[38;5;241m.\u001b[39mtype, np\u001b[38;5;241m.\u001b[39mbool_):\n\u001b[1;32m     86\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m indexer\u001b[38;5;241m.\u001b[39mshape \u001b[38;5;241m!=\u001b[39m index\u001b[38;5;241m.\u001b[39mshape:\n\u001b[0;32m---> 87\u001b[0m         \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mIndexError\u001b[39;00m(\n\u001b[1;32m     88\u001b[0m             \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mBoolean index does not match AnnData’s shape along this \u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m     89\u001b[0m             \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mdimension. Boolean index has shape \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mindexer\u001b[38;5;241m.\u001b[39mshape\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m while \u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m     90\u001b[0m             \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mAnnData index has shape \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mindex\u001b[38;5;241m.\u001b[39mshape\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m.\u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m     91\u001b[0m         )\n\u001b[1;32m     92\u001b[0m     positions \u001b[38;5;241m=\u001b[39m np\u001b[38;5;241m.\u001b[39mwhere(indexer)[\u001b[38;5;241m0\u001b[39m]\n\u001b[1;32m     93\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m positions  \u001b[38;5;66;03m# np.ndarray[int]\u001b[39;00m\n",
+      "\u001b[0;31mIndexError\u001b[0m: Boolean index does not match AnnData’s shape along this dimension. Boolean index has shape (1695,) while AnnData index has shape (36811,)."
+     ]
+    }
+   ],
+   "source": [
+    "gdo_adata_v1 = gdo_adata_v1[:,gdo_adata.var['feature_types']==\"CRISPR Guide Capture\"]\n",
+    "mdata_v1 = md.MuData({\"cdna\": cdna_adata_filt, \"hto\": hto_adata_filt, \"gdo\": gdo_adata_filt})\n",
+    "mdata_v1 = mdata_v1[metadata_v1.index]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 58,
+   "id": "d60af6ee-045d-42a9-a66a-5a3ce154102e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/local/lib/python3.10/dist-packages/anndata/_core/anndata.py:1222: ImplicitModificationWarning: Trying to modify attribute `.var` of view, initializing view as actual.\n",
+      "  df[key] = c\n",
+      "/usr/local/lib/python3.10/dist-packages/anndata/_core/anndata.py:1222: ImplicitModificationWarning: Trying to modify attribute `.var` of view, initializing view as actual.\n",
+      "  df[key] = c\n",
+      "/usr/local/lib/python3.10/dist-packages/anndata/_core/anndata.py:1222: ImplicitModificationWarning: Trying to modify attribute `.var` of view, initializing view as actual.\n",
+      "  df[key] = c\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre>MuData object with n_obs × n_vars = 7667 × 36815\n",
+       "  obs:\t&#x27;Library&#x27;, &#x27;Lane Batch&#x27;, &#x27;Cell Barcode&#x27;, &#x27;Total Gene Expression UMIs&#x27;, &#x27;Unique Genes&#x27;, &#x27;Mitochondrial Percentage&#x27;, &#x27;Total gRNA Expression UMIs&#x27;, &#x27;Unique gRNAs (after adaptive thresholding)&#x27;, &#x27;Total ADT UMIs&#x27;, &#x27;Total HTO UMIs&#x27;, &#x27;ADT CTL1&#x27;, &#x27;ADT CTL2&#x27;, &#x27;ADT CTL3&#x27;, &#x27;ADT CTL4&#x27;\n",
+       "  var:\t&#x27;gene_ids&#x27;, &#x27;feature_types&#x27;\n",
+       "  3 modalities\n",
+       "    cdna:\t7667 x 36601\n",
+       "      var:\t&#x27;gene_ids&#x27;, &#x27;feature_types&#x27;\n",
+       "    hto:\t7667 x 4\n",
+       "      var:\t&#x27;gene_ids&#x27;, &#x27;feature_types&#x27;\n",
+       "    gdo:\t7667 x 210\n",
+       "      var:\t&#x27;gene_ids&#x27;, &#x27;feature_types&#x27;</pre>"
+      ],
+      "text/plain": [
+       "MuData object with n_obs × n_vars = 7667 × 36815\n",
+       "  obs:\t'Library', 'Lane Batch', 'Cell Barcode', 'Total Gene Expression UMIs', 'Unique Genes', 'Mitochondrial Percentage', 'Total gRNA Expression UMIs', 'Unique gRNAs (after adaptive thresholding)', 'Total ADT UMIs', 'Total HTO UMIs', 'ADT CTL1', 'ADT CTL2', 'ADT CTL3', 'ADT CTL4'\n",
+       "  var:\t'gene_ids', 'feature_types'\n",
+       "  3 modalities\n",
+       "    cdna:\t7667 x 36601\n",
+       "      var:\t'gene_ids', 'feature_types'\n",
+       "    hto:\t7667 x 4\n",
+       "      var:\t'gene_ids', 'feature_types'\n",
+       "    gdo:\t7667 x 210\n",
+       "      var:\t'gene_ids', 'feature_types'"
+      ]
+     },
+     "execution_count": 58,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "file_path = f\"{data_dir}/STINGseq-v1.h5mu\"\n",
+    "\n",
+    "mdata.obs = v1_metadata\n",
+    "mdata.write(file_path)\n",
+    "mdata"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6171461f-c9ac-4d5a-be42-6ffc0c1d8134",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/perturbo/_module.py
+++ b/src/perturbo/_module.py
@@ -67,6 +67,10 @@ class PerTurboPyroModule(PyroBaseModuleClass):
         self.n_batches = summary_stats.n_batch
         self.likelihood = likelihood
 
+    # required to override broken method in PyroBaseModuleClass
+    def on_load(self, model):
+        pass
+
     @staticmethod
     def _get_fn_args_from_batch(tensor_dict):
         # tack on size factor after the other continuous covariates

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -61,7 +61,7 @@ def test_package_has_version():
     assert perturbo.__version__ is not None
 
 
-def test_model_mdata(mdata: MuData):
+def test_model_mdata(mdata: MuData, tmp_path):
     """Check that we can register our MuData object with our model and perform training"""
     perturbo.PERTURBO.setup_mudata(
         mdata,
@@ -78,7 +78,7 @@ def test_model_mdata(mdata: MuData):
     assert model.summary_stats.n_vars == len(mdata[rna_key].var)
     assert model.summary_stats.n_perturbations == len(mdata[perturb_key].var)
 
-    model.train(max_epochs=10, train_size=1, lr=0.1)
+    model.train(max_epochs=10, lr=0.1)
     samples = model.get_posterior_samples()
     assert samples["obs"].shape[-2:] == (
         model.summary_stats.n_cells,
@@ -86,8 +86,11 @@ def test_model_mdata(mdata: MuData):
     )
     print(model.view_anndata_setup())
 
+    model.save(tmp_path / "model", save_anndata=True)
+    model = perturbo.PERTURBO.load(tmp_path / "model")
+    model.train(max_epochs=1, lr=0.1)
 
-def test_model_adata(adata: AnnData):
+def test_model_adata(adata: AnnData, tmp_path):
     """Check that we can register our AnnData object with our model and perform training"""
     perturbo.PERTURBO.setup_anndata(
         adata,
@@ -101,9 +104,14 @@ def test_model_adata(adata: AnnData):
     assert model.summary_stats.n_cells == n_cells
     assert model.summary_stats.n_vars == n_vars
     assert model.summary_stats.n_perturbations == adata.obsm[perturb_key].shape[1]
-    model.train(max_epochs=10, train_size=1, lr=0.1)
+    model.train(max_epochs=10, lr=0.1)
     samples = model.get_posterior_samples()
+
     assert samples["obs"].shape[-2:] == (
         model.summary_stats.n_cells,
         model.summary_stats.n_vars,
     )
+
+    model.save(tmp_path / "model", save_anndata=True)
+    model = perturbo.PERTURBO.load(tmp_path / "model")
+    model.train(max_epochs=1, lr=0.1)


### PR DESCRIPTION
Fixed the inheritance from PyroBaseModuleClass so we can use `model.save()` and `perturbo.PERTURBO.load()` to save/load models. Also updated tests to make sure we don't break this in the future