### PR TITLE
add high moi mixture simulator

### DIFF
--- a/src/perturbo/models/_module.py
+++ b/src/perturbo/models/_module.py
@@ -359,6 +359,10 @@ class PerTurboPyroModule(PyroBaseModuleClass):
             elif self.efficiency_mode == "mixture":
                 pert_prob = guides_observed @ guide_efficacy
                 perturbed = pyro.sample("perturbed", dist.Bernoulli(pert_prob), infer={"enumerate": "parallel"})
+            elif self.efficiency_mode == "mixture_high_moi":  # for simulation only!
+                pert_prob = guide_efficacy.expand((self.n_cells, -1, -1)).transpose(-3, -2)
+                assert pert_prob.shape == (self.n_perturbations, self.n_cells, 1)
+                perturbed = pyro.sample("perturbed", dist.Bernoulli(pert_prob)).squeeze(-1).T
             else:
                 raise Exception("efficiency_mode must be either 'scaled' or 'mixture'")
 

--- a/src/perturbo/simulation/_pyro_simulator.py
+++ b/src/perturbo/simulation/_pyro_simulator.py
@@ -135,6 +135,20 @@ def simulate_data_from_trained_model(
     if param_values is not None:
         latent_vars.update(param_values)
 
+    module_kwargs = {
+        "n_batches": model.module.n_batches,
+        "n_cont_covariates": model.module.n_cont_covariates - 1,  # size factor auto included
+        "n_factors": model.module.n_factors,
+        "dispersion_effects": model.module.dispersion_effects,
+        "likelihood": model.module.likelihood,
+        "effect_prior_dist": model.module.effect_prior_dist,
+        "use_interactions": model.module.use_interactions,
+        "efficiency_mode": model.module.efficiency_mode,
+    }
+
+    if module_init_kwargs is not None:
+        module_kwargs.update(module_init_kwargs)
+
     # create new module to sample from
     module_new = PerTurboPyroModule(
         n_cells=n_cells,
@@ -142,15 +156,7 @@ def simulate_data_from_trained_model(
         n_elements=n_elements,
         n_perturbations=n_guides,
         guide_by_element=guide_by_element,
-        n_batches=model.module.n_batches,
-        n_cont_covariates=model.module.n_cont_covariates - 1,  # size factor auto included
-        n_factors=model.module.n_factors,
-        dispersion_effects=model.module.dispersion_effects,
-        likelihood=model.module.likelihood,
-        effect_prior_dist=model.module.effect_prior_dist,
-        use_interactions=model.module.use_interactions,
-        efficiency_mode=model.module.efficiency_mode,
-        **module_init_kwargs,
+        **module_kwargs,
     )
     module_new.to(device)
 
@@ -159,7 +165,6 @@ def simulate_data_from_trained_model(
     sampled_counts = conditioned_model(*args, **kwargs).squeeze().detach().cpu().numpy()
 
     # Create an AnnData object to return
-
     data_registry = model.adata_manager.data_registry
     rna_key = data_registry[REGISTRY_KEYS.X_KEY].mod_key
     grna_key = data_registry[REGISTRY_KEYS.PERTURBATION_KEY].mod_key

--- a/src/perturbo/simulation/_pyro_simulator.py
+++ b/src/perturbo/simulation/_pyro_simulator.py
@@ -123,6 +123,7 @@ def simulate_data_from_trained_model(
             latent_vars[param_name] = param_value[..., gene_indices_tensor]
 
     if element_by_gene_lfc is not None:
+        assert element_by_gene_lfc.shape[1] == n_genes_new
         element_by_gene_lfc = torch.tensor(element_by_gene_lfc, dtype=torch.float32, device=device)
         latent_vars["element_effects"] = element_by_gene_lfc
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -97,6 +97,7 @@ def test_model_mdata(
         element_by_gene_lfc=element_by_gene_lfc,
         guide_efficacy=guide_efficacy,
         gene_indices=new_genes_idx,
+        module_init_kwargs={"efficiency_mode": "mixture_high_moi"},
     )
 
     assert mdata_new[rna_key].shape == (n_cells_new, n_genes_new)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -75,27 +75,48 @@ def test_model_mdata(
     model = perturbo.PERTURBO.load(tmp_path / "model")
 
     # test simulator
+    n_cells = mdata[rna_key].n_obs
+    n_cells_new = n_cells * 2  # greater than original
+    n_genes = mdata[rna_key].n_vars
+
+    grna_counts = mdata[perturb_key].X
+    cell_idx = np.arange(3)
+
+    # run simulator once with original settings
+    guide_by_element = np.random.binomial(1, 0.8, size=(model.module.n_perturbations, model.module.n_elements))
+    element_by_gene_lfc = np.random.normal(0, 1, size=(model.module.n_elements, model.module.n_genes))
+
+    guide_efficacy = np.random.random_sample(size=(model.module.n_perturbations, 1))
+
+    mdata_new = perturbo.simulation.simulate_data_from_trained_model(
+        model,
+        guide_obs=grna_counts.todense()[cell_idx, :],
+        guide_by_element=guide_by_element,
+        element_by_gene_lfc=element_by_gene_lfc,
+        guide_efficacy=guide_efficacy,
+        cell_indices=cell_idx,
+    )
+
+    # run simulator once with new data shape/model
     n_grna_new = 16
     n_elements_new = 4
-    n_cells_new = mdata[rna_key].n_obs * 2  # greater than original
-    n_genes = mdata[rna_key].n_vars
-    n_genes_new = n_genes // 2  # less than original
-    new_genes_idx = np.random.choice(n_genes, size=n_genes_new, replace=False)
-    guide_by_element_new = np.random.binomial(1, 0.8, size=(n_grna_new, n_elements_new)).astype(np.float32)
-    element_by_gene_lfc = np.random.normal(0, 1, size=(n_elements_new, n_genes_new)).astype(np.float32)
-    # generate fake guide status (low MOI)
+
     grna_counts_new = np.zeros((n_cells_new, n_grna_new), dtype=np.float32)
-    guide_efficacy = np.random.uniform(size=(n_grna_new,))
+    guide_efficacy_new = np.random.uniform(size=(n_grna_new,))
     for i in range(n_cells_new):
         grna_counts_new[i, np.random.choice(n_grna_new)] = 1
 
-    # run simulator once with new args
+    n_genes_new = n_genes // 2  # less than original
+    new_genes_idx = np.random.choice(n_genes, size=n_genes_new, replace=False)
+    guide_by_element_new = np.random.binomial(1, 0.8, size=(n_grna_new, n_elements_new))
+    element_by_gene_lfc_new = np.random.normal(0, 1, size=(n_elements_new, n_genes_new))
+
     mdata_new = perturbo.simulation.simulate_data_from_trained_model(
         model,
         guide_obs=grna_counts_new,
         guide_by_element=guide_by_element_new,
-        element_by_gene_lfc=element_by_gene_lfc,
-        guide_efficacy=guide_efficacy,
+        element_by_gene_lfc=element_by_gene_lfc_new,
+        guide_efficacy=guide_efficacy_new,
         gene_indices=new_genes_idx,
         module_init_kwargs={"efficiency_mode": "mixture_high_moi"},
     )


### PR DESCRIPTION
Added the option to simulate from the high moi mixture model (even though enumerated inference is intractable) using trained parameters from the GLM-style model.   

You can see an example in the unit test -- should work if you just add `module_init_kwargs={"efficiency_mode": "mixture_high_moi"}` to the simulator call.