### PR TITLE
Optimize pair-restricted and high-MOI JAX fitting

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,22 @@ perturbo --input screen.h5mu --out-dir perturbo_outputs/run --modality-key rna \
   --perturbation-modality-key grna --perturbation-element-varm-key element_targeted
 ```
 
+For a CIS-only or otherwise preselected analysis, pass a CSV, TSV, or Parquet
+table whose required columns are `element` and `gene`:
+
+```bash
+perturbo --input screen.h5mu --out-dir perturbo_outputs/cis --modality-key rna \
+  --perturbation-modality-key grna --perturbation-element-varm-key element_targeted \
+  --pairs-to-test cis_pairs.parquet --minibatch-size-betas 1024
+```
+
+Only those exact coefficients are sampled; the pair list is not expanded to
+an element-by-gene Cartesian product. PerTurbo subsets the RNA genes and
+perturbation elements to the pair-list union before transfer to JAX. A beta
+minibatch uses one global compiled fit by default. Use
+`--perturbation-chunk-size` explicitly only when the full design does not fit
+in device memory, since each distinct chunk shape can require compilation.
+
 The main Python entry points are `PERTURBO` / `PerTurboModel`, `fit_from_path`,
 `setup_mudata`, `fit_control`, `fit_perturbation_effects`, and the posterior
 table and trained-model simulation helpers.

--- a/src/perturbo/api.py
+++ b/src/perturbo/api.py
@@ -110,6 +110,7 @@ def fit_from_path(
     library_size_key: str | None = None,
     size_factor_mode: str = "infer",
     gene_name_key: str | None = None,
+    pairs_to_test: str | Path | None = None,
     clip_gene_expression_percentile: float = 100.0,
     gene_outlier_action: str = "none",
     gene_outlier_threshold_floor: int = 2,
@@ -165,6 +166,7 @@ def fit_from_path(
     _append_cli_arg(argv, "--library-size-key", library_size_key)
     _append_cli_arg(argv, "--size-factor-mode", size_factor_mode)
     _append_cli_arg(argv, "--gene-name-key", gene_name_key)
+    _append_cli_arg(argv, "--pairs-to-test", pairs_to_test)
     _append_cli_arg(argv, "--clip-gene-expression-percentile", clip_gene_expression_percentile)
     _append_cli_arg(argv, "--gene-outlier-action", gene_outlier_action)
     _append_cli_arg(argv, "--gene-outlier-threshold-floor", gene_outlier_threshold_floor)

--- a/src/perturbo/cli.py
+++ b/src/perturbo/cli.py
@@ -22,6 +22,7 @@ from .core import (
     _PerturbationChunk,
     _build_matrix_membership,
     _build_obs_membership,
+    build_effect_indices,
     _compute_gene_outlier_thresholds,
     _construct_perturbation_chunks,
     _count_gene_outliers_per_cell,
@@ -38,6 +39,7 @@ from .core import (
     _resolve_adata,
     _resolve_cli_size_factor_mode,
     _resolve_control_element_mask,
+    _resolve_gene_subset_indices,
     _resolve_perturbation_modality,
     _save_loss_plot,
     _save_multi_loss_plot,
@@ -62,6 +64,7 @@ def _beta_fit_arrays(beta_fit: BetaFit) -> dict[str, Any]:
         "z_values": beta_fit.z_values,
         "losses": beta_fit.losses,
         "dispersion_excess_inverse": beta_fit.dispersion_excess_inverse,
+        "effect_indices": beta_fit.effect_indices,
     }
 
 
@@ -95,6 +98,28 @@ def _guide_efficacy_for_cli(
     if arr.ndim == 1:
         return np.clip(arr, a_min=0.0, a_max=None)
     return np.clip(arr.reshape(int(n_guides), -1).mean(axis=1), a_min=0.0, a_max=None).astype(np.float32)
+
+
+def _load_pairs_to_test(path: str | Path) -> pd.DataFrame:
+    pair_path = Path(path)
+    if not pair_path.exists():
+        raise FileNotFoundError(f"pairs-to-test file not found: {pair_path}")
+    if pair_path.suffix.lower() in {".parquet", ".pq"}:
+        frame = pd.read_parquet(pair_path)
+    else:
+        frame = pd.read_csv(pair_path, sep=None, engine="python")
+    required = {"element", "gene"}
+    missing = required.difference(frame.columns)
+    if missing:
+        raise ValueError(
+            f"--pairs-to-test requires columns named 'element' and 'gene'; missing {sorted(missing)}."
+        )
+    if frame[["element", "gene"]].isna().any().any():
+        raise ValueError("--pairs-to-test contains missing element or gene names.")
+    frame = frame.loc[:, ["element", "gene"]].astype(str).drop_duplicates(ignore_index=True)
+    if frame.empty:
+        raise ValueError("--pairs-to-test must contain at least one pair.")
+    return frame
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -186,6 +211,14 @@ def main(argv: list[str] | None = None) -> None:
         ),
     )
     parser.add_argument("--gene-name-key", default=None, help="Var field for gene names")
+    parser.add_argument(
+        "--pairs-to-test",
+        default=None,
+        help=(
+            "CSV, TSV, or Parquet table with element and gene columns. Stage 2 samples only these exact pairs; "
+            "the RNA and perturbation inputs are subset to their union before fitting."
+        ),
+    )
     parser.add_argument(
         "--clip-gene-expression-percentile",
         type=float,
@@ -428,6 +461,16 @@ def main(argv: list[str] | None = None) -> None:
         f"[perturbo] Input loaded in {_load_elapsed:.1f}s: "
         f"{getattr(_loaded_adata, 'n_obs', '?')} cells × {getattr(_loaded_adata, 'n_vars', '?')} genes"
     )
+    pairs_to_test = _load_pairs_to_test(args.pairs_to_test) if args.pairs_to_test is not None else None
+    selected_elements = (
+        list(dict.fromkeys(pairs_to_test["element"].tolist())) if pairs_to_test is not None else None
+    )
+    selected_genes = list(dict.fromkeys(pairs_to_test["gene"].tolist())) if pairs_to_test is not None else None
+    if pairs_to_test is not None:
+        print(
+            f"[perturbo] Pair-restricted fit: {len(pairs_to_test)} exact pairs, "
+            f"{len(selected_elements)} elements, {len(selected_genes)} genes."
+        )
     out_dir = Path(args.out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
     print(f"[perturbo] Outputs will be written to: {out_dir}")
@@ -472,6 +515,8 @@ def main(argv: list[str] | None = None) -> None:
         raise ValueError(
             "--guide-activity-mode=absolute is currently only compatible with negative-binomial likelihoods."
         )
+    if pairs_to_test is not None and args.fit_perturbation_dispersion:
+        raise ValueError("--pairs-to-test is not yet compatible with --fit-perturbation-dispersion.")
 
     clip_percentile = _validate_clip_percentile(args.clip_gene_expression_percentile)
     if _is_censored_model_name(args.likelihood) and clip_percentile >= 100.0:
@@ -509,6 +554,9 @@ def main(argv: list[str] | None = None) -> None:
     if not apply_filter_cells and args.outlier_cell_min_genes != 0:
         raise ValueError("--outlier-cell-min-genes requires --gene-outlier-action=filter_cells or both.")
     analysis_adata = _resolve_adata(data, args.modality_key)
+    if selected_genes is not None:
+        gene_idx = _resolve_gene_subset_indices(analysis_adata, selected_genes, args.gene_name_key)
+        analysis_adata = analysis_adata[:, gene_idx]
     _row_chunk_size = BACKED_ROW_CHUNK_SIZE if args.backed else None
     gene_clip_thresholds = None
     if (apply_filter_cells or apply_winsorize) and clip_percentile is not None and clip_percentile < 100.0:
@@ -547,12 +595,31 @@ def main(argv: list[str] | None = None) -> None:
         analysis_adata_for_workflow = analysis_adata
 
     should_chunk = False
-    retain_guide_structure = args.perturbation_element_varm_key is not None
+    retain_guide_structure = bool(
+        args.perturbation_element_varm_key is not None
+        and (guide_effect_strategy != "shared" or args.guide_random_effects or args.fit_perturbation_dispersion)
+    )
     n_analysis_cells = getattr(analysis_adata_for_workflow, "n_obs", None)
+    requested_beta_minibatch = args.minibatch_size_betas or args.minibatch_size or 0
     if args.perturbation_chunk_size > 0:
         should_chunk = True
-    elif n_analysis_cells is not None and n_analysis_cells > args.max_chunk_size:
+    elif (
+        n_analysis_cells is not None
+        and n_analysis_cells > args.max_chunk_size
+        and requested_beta_minibatch == 0
+    ):
         should_chunk = True
+        print(
+            "[perturbo] Auto chunking enabled because the analysis dataset has "
+            f"{n_analysis_cells} cells; chunk cell counts will be capped at "
+            f"--max-chunk-size={args.max_chunk_size}."
+        )
+    elif n_analysis_cells is not None and n_analysis_cells > args.max_chunk_size:
+        print(
+            "[perturbo] Stage-2 minibatching enabled; using one global fit to avoid "
+            "a separate JAX compilation for every perturbation chunk. Use "
+            "--perturbation-chunk-size explicitly if the full design does not fit in device memory."
+        )
     if (
         should_chunk
         and args.fit_perturbation_dispersion
@@ -561,11 +628,6 @@ def main(argv: list[str] | None = None) -> None:
         raise ValueError(
             "High-MOI fitted perturbation dispersion is not yet compatible with CLI perturbation chunking; "
             "increase --max-chunk-size or disable --perturbation-chunk-size."
-        )
-        print(
-            "[perturbo] Auto chunking enabled because the analysis dataset has "
-            f"{n_analysis_cells} cells; chunk cell counts will be capped at "
-            f"--max-chunk-size={args.max_chunk_size}."
         )
 
     if should_chunk:
@@ -585,6 +647,14 @@ def main(argv: list[str] | None = None) -> None:
                 all_perturbation_names = element_names
             else:
                 all_perturbation_names = _extract_pert_names(pert_adata)
+            if selected_elements is not None:
+                name_to_idx = {name: idx for idx, name in enumerate(all_perturbation_names)}
+                missing = [name for name in selected_elements if name not in name_to_idx]
+                if missing:
+                    raise KeyError(f"Pair-list elements not found in perturbation data: {missing[:10]}")
+                selected_idx = [name_to_idx[name] for name in selected_elements]
+                pert_matrix = pert_matrix[:, selected_idx]
+                all_perturbation_names = list(selected_elements)
             membership = _build_matrix_membership(
                 pert_matrix,
                 num_perts=len(all_perturbation_names),
@@ -597,7 +667,11 @@ def main(argv: list[str] | None = None) -> None:
             )
         else:
             pert_series = analysis_adata_for_workflow.obs[args.perturbation_key].astype(str)
-            all_perturbation_names = [str(x) for x in pd.Categorical(pert_series).categories.tolist()]
+            all_perturbation_names = (
+                list(selected_elements)
+                if selected_elements is not None
+                else [str(x) for x in pd.Categorical(pert_series).categories.tolist()]
+            )
             membership = _build_obs_membership(pert_series, all_perturbation_names)
             chunks = _construct_perturbation_chunks(
                 all_perturbation_names,
@@ -619,6 +693,7 @@ def main(argv: list[str] | None = None) -> None:
         size_factor_key=size_factor_key_for_loading,
         library_size_key=library_size_key_for_loading,
         gene_name_key=args.gene_name_key,
+        selected_genes=selected_genes,
         device=args.device,
         cell_keep_mask=cell_keep_mask,
         clip_gene_expression_percentile=clip_percentile,
@@ -629,6 +704,7 @@ def main(argv: list[str] | None = None) -> None:
         batch_covariate=batch_covariate,
         return_covariate_transform_state=True,
         infer_control_guides=bool(args.guide_random_effects and args.perturbation_modality_key is not None),
+        retain_perturbation_design=bool(args.guide_random_effects),
     )
     if isinstance(controls_loaded, tuple):
         controls, covariate_transform_state = controls_loaded
@@ -692,9 +768,10 @@ def main(argv: list[str] | None = None) -> None:
             raise RuntimeError("Chunk metadata was not initialized.")
         n_genes = len(analysis_gene_names)
         n_perts = len(all_perturbation_names)
-        posterior_mean = np.zeros((n_perts, n_genes), dtype=np.float32)
-        posterior_scale = np.zeros((n_perts, n_genes), dtype=np.float32)
-        z_values = np.zeros((n_perts, n_genes), dtype=np.float32)
+        fill_value = np.nan if pairs_to_test is not None else 0.0
+        posterior_mean = np.full((n_perts, n_genes), fill_value, dtype=np.float32)
+        posterior_scale = np.full((n_perts, n_genes), fill_value, dtype=np.float32)
+        z_values = np.full((n_perts, n_genes), fill_value, dtype=np.float32)
         dispersion_excess_inverse = np.zeros((n_perts, n_genes), dtype=np.float32) if args.fit_perturbation_dispersion else None
         last_state = None
         for chunk_i, chunk_info in enumerate(chunks):
@@ -721,6 +798,7 @@ def main(argv: list[str] | None = None) -> None:
                 gene_name_key=args.gene_name_key,
                 device=args.device,
                 selected_perturbations=chunk_names,
+                selected_genes=selected_genes,
                 cell_keep_mask=cell_keep_mask,
                 clip_gene_expression_percentile=clip_percentile,
                 winsorize_gene_expression=apply_winsorize,
@@ -732,6 +810,15 @@ def main(argv: list[str] | None = None) -> None:
                 retain_guide_structure=retain_guide_structure,
                 library_size_center_log_mean=controls.library_size_center_log_mean,
             )
+            if pairs_to_test is not None:
+                chunk_pairs = pairs_to_test[pairs_to_test["element"].isin(chunk_names)]
+                chunk_data.effect_indices = jnp.asarray(
+                    build_effect_indices(
+                        chunk_pairs,
+                        pert_names=chunk_data.pert_names,
+                        gene_names=chunk_data.gene_names,
+                    )
+                )
             if size_factor_mode == "none":
                 chunk_data.size_factors = _fixed_zero_size_factors(chunk_data.counts)
             chunk_fit = fit_perturbation_effects(
@@ -795,6 +882,17 @@ def main(argv: list[str] | None = None) -> None:
             losses=jnp.concatenate(chunk_losses) if chunk_losses else jnp.array([]),
             svi_result=last_state,
             dispersion_excess_inverse=None if dispersion_excess_inverse is None else jnp.asarray(dispersion_excess_inverse),
+            effect_indices=(
+                None
+                if pairs_to_test is None
+                else jnp.asarray(
+                    build_effect_indices(
+                        pairs_to_test,
+                        pert_names=list(all_perturbation_names),
+                        gene_names=list(analysis_gene_names),
+                    )
+                )
+            ),
         )
         # full = PerTurboData(
         #     counts=jnp.empty((0, len(analysis_gene_names))),
@@ -816,6 +914,8 @@ def main(argv: list[str] | None = None) -> None:
             library_size_key=library_size_key_for_loading,
             gene_name_key=args.gene_name_key,
             device=args.device,
+            selected_perturbations=selected_elements,
+            selected_genes=selected_genes,
             cell_keep_mask=cell_keep_mask,
             clip_gene_expression_percentile=clip_percentile,
             winsorize_gene_expression=apply_winsorize,
@@ -827,6 +927,14 @@ def main(argv: list[str] | None = None) -> None:
             retain_guide_structure=retain_guide_structure,
             library_size_center_log_mean=controls.library_size_center_log_mean,
         )
+        if pairs_to_test is not None:
+            analysis_data.effect_indices = jnp.asarray(
+                build_effect_indices(
+                    pairs_to_test,
+                    pert_names=analysis_data.pert_names,
+                    gene_names=analysis_data.gene_names,
+                )
+            )
         if size_factor_mode == "none":
             analysis_data.size_factors = _fixed_zero_size_factors(analysis_data.counts)
         all_perturbation_names = analysis_data.pert_names
@@ -876,6 +984,10 @@ def main(argv: list[str] | None = None) -> None:
         gene_names=list(analysis_gene_names),
         null_z_values=null_z_values,
     )
+    if pairs_to_test is not None:
+        requested_pairs = pd.MultiIndex.from_frame(pairs_to_test[["element", "gene"]])
+        output_pairs = pd.MultiIndex.from_frame(element_effects[["element", "gene"]])
+        element_effects = element_effects.loc[output_pairs.isin(requested_pairs)].reset_index(drop=True)
     element_effects_path = out_dir / "element_effects.parquet"
     element_effects.to_parquet(element_effects_path, index=False)
     print(f"[perturbo] Wrote {element_effects_path}")

--- a/src/perturbo/core.py
+++ b/src/perturbo/core.py
@@ -86,6 +86,9 @@ class PerTurboData:
     guide_matrix: jnp.ndarray | None = None
     guide_names: list[str] | None = None
     guide_to_element: jnp.ndarray | None = None
+    # Integer (element_index, gene_index) rows. When provided, stage 2 samples
+    # only these coefficients instead of the full element-by-gene product.
+    effect_indices: jnp.ndarray | None = None
     library_size_center_log_mean: float | None = None
 
 
@@ -136,6 +139,7 @@ class BetaFit:
     guide_offset_scale: jnp.ndarray | None = None
     dispersion_excess_inverse: jnp.ndarray | None = None
     guide_dispersion_excess_inverse: jnp.ndarray | None = None
+    effect_indices: jnp.ndarray | None = None
 
 
 @dataclass
@@ -337,29 +341,32 @@ def _run_svi_minibatch(
 
     update_impl = svi.stable_update if stable_update else svi.update
 
-    def update_step(
+    def run_index_steps(
         state: numpyro.infer.svi.SVIState,
         counts_full: jnp.ndarray | None,
         pert_full: jnp.ndarray | None,
         size_full: jnp.ndarray | None,
         covariate_full: jnp.ndarray | None,
         guide_matrix_full: jnp.ndarray | None,
-        idx: np.ndarray,
+        batch_indices: jnp.ndarray,
     ):
-        return update_impl(
-            state,
-            counts_full,
-            pert_full,
-            size_factors=size_full,
-            covariates=covariate_full,
-            guide_matrix=guide_matrix_full,
-            cell_idx=idx,
-            num_cells=num_cells,
-            forward_mode_differentiation=forward_mode_differentiation,
-            **static_kwargs,
-        )
+        def body_fn(carry, idx):
+            return update_impl(
+                carry,
+                counts_full,
+                pert_full,
+                size_factors=size_full,
+                covariates=covariate_full,
+                guide_matrix=guide_matrix_full,
+                cell_idx=idx,
+                num_cells=num_cells,
+                forward_mode_differentiation=forward_mode_differentiation,
+                **static_kwargs,
+            )
 
-    update_step = jax.jit(update_step)
+        return jax.lax.scan(body_fn, state, batch_indices)
+
+    run_index_steps = jax.jit(run_index_steps)
 
     if init_state is None:
         init_idx = sample_indices()
@@ -382,43 +389,43 @@ def _run_svi_minibatch(
     if progress_chunk_size < 1:
         raise ValueError("progress_chunk_size must be >= 1.")
 
-    losses = []
+    all_batch_indices = np.stack([sample_indices() for _ in range(num_steps)], axis=0)
+    losses_chunks = []
     remaining = num_steps
+    offset = 0
     if progress:
         with tqdm(total=num_steps, desc="[perturbo] SVI", unit="step") as pbar:
             while remaining > 0:
                 step_count = min(progress_chunk_size, remaining)
-                for _ in range(step_count):
-                    idx = sample_indices()
-                    svi_state, loss = update_step(
-                        svi_state,
-                        counts,
-                        pert_id,
-                        size_factors,
-                        covariates,
-                        guide_matrix,
-                        idx,
-                    )
-                    loss = jax.block_until_ready(loss)
-                    losses.append(loss)
-                    pbar.set_postfix(loss=float(np.asarray(loss)))
-                    pbar.update(1)
+                index_chunk = jnp.asarray(all_batch_indices[offset : offset + step_count])
+                svi_state, losses = run_index_steps(
+                    svi_state,
+                    counts,
+                    pert_id,
+                    size_factors,
+                    covariates,
+                    guide_matrix,
+                    index_chunk,
+                )
+                losses = jax.block_until_ready(losses)
+                losses_chunks.append(losses)
+                pbar.set_postfix(loss=float(np.asarray(losses[-1])))
+                pbar.update(step_count)
+                offset += step_count
                 remaining -= step_count
     else:
-        for _ in range(num_steps):
-            idx = sample_indices()
-            svi_state, loss = update_step(
-                svi_state,
-                counts,
-                pert_id,
-                size_factors,
-                covariates,
-                guide_matrix,
-                idx,
-            )
-            losses.append(loss)
+        svi_state, losses = run_index_steps(
+            svi_state,
+            counts,
+            pert_id,
+            size_factors,
+            covariates,
+            guide_matrix,
+            jnp.asarray(all_batch_indices),
+        )
+        losses_chunks.append(losses)
 
-    losses_arr = jnp.stack(losses) if losses else jnp.array([])
+    losses_arr = jnp.concatenate(losses_chunks) if len(losses_chunks) > 1 else losses_chunks[0]
     return _SVIRunResult(params=svi.get_params(svi_state), state=svi_state, losses=losses_arr)
 
 
@@ -1104,7 +1111,7 @@ def _load_guide_shared_perturbation_data(
     perturbation_element_names_uns_key: str | None,
     obs_names,
     element_subset: list[str] | None = None,
-) -> tuple[np.ndarray, list[str], np.ndarray, np.ndarray, list[str]]:
+) -> tuple[np.ndarray, list[str], np.ndarray, np.ndarray, list[str], np.ndarray | None]:
     pert_adata = _resolve_perturbation_modality(data, perturbation_modality_key)
     if obs_names is not None:
         pert_adata = pert_adata[obs_names]
@@ -1130,12 +1137,18 @@ def _load_guide_shared_perturbation_data(
     else:
         element_names = list(all_element_names)
     grouped = _group_perturbation_matrix_by_element(raw_matrix, element_mapping)
+    row_mask = None
+    if element_subset is not None:
+        row_mask = np.asarray(grouped).sum(axis=1) > 0
+        raw_matrix = raw_matrix[row_mask]
+        grouped = grouped[row_mask]
     return (
         _to_dense(raw_matrix),
         guide_names,
         grouped,
         np.asarray(element_mapping > 0, dtype=np.float32),
         element_names,
+        row_mask,
     )
 
 
@@ -1322,6 +1335,59 @@ def _extract_gene_names(adata, gene_name_key: str | None) -> list[str]:
     return adata.var.index.astype(str).tolist()
 
 
+def _resolve_gene_subset_indices(
+    adata,
+    selected_genes: list[str] | None,
+    gene_name_key: str | None,
+) -> np.ndarray | slice:
+    """Resolve requested gene labels without materializing an AnnData view."""
+    if selected_genes is None:
+        return slice(None)
+    requested = [str(name) for name in selected_genes]
+    if not requested:
+        raise ValueError("selected_genes must contain at least one gene.")
+    if len(set(requested)) != len(requested):
+        raise ValueError("selected_genes must be unique.")
+    available = _extract_gene_names(adata, gene_name_key)
+    name_to_idx = {name: idx for idx, name in enumerate(available)}
+    missing = [name for name in requested if name not in name_to_idx]
+    if missing:
+        preview = ", ".join(missing[:10])
+        raise KeyError(f"Genes not found in analysis modality: {preview}")
+    return np.asarray([name_to_idx[name] for name in requested], dtype=np.int64)
+
+
+def build_effect_indices(
+    pairs: pd.DataFrame,
+    *,
+    pert_names: list[str],
+    gene_names: list[str],
+) -> np.ndarray:
+    """Map an exact element/gene pair table to local integer coefficient indices."""
+    required = {"element", "gene"}
+    missing_columns = required.difference(pairs.columns)
+    if missing_columns:
+        raise ValueError(f"pairs_to_test is missing required columns: {sorted(missing_columns)}")
+    pair_frame = pairs.loc[:, ["element", "gene"]].astype(str).drop_duplicates(ignore_index=True)
+    if pair_frame.empty:
+        raise ValueError("pairs_to_test must contain at least one element/gene pair.")
+    pert_lookup = {str(name): idx for idx, name in enumerate(pert_names)}
+    gene_lookup = {str(name): idx for idx, name in enumerate(gene_names)}
+    missing_elements = sorted(set(pair_frame["element"]).difference(pert_lookup))
+    missing_genes = sorted(set(pair_frame["gene"]).difference(gene_lookup))
+    if missing_elements or missing_genes:
+        details = []
+        if missing_elements:
+            details.append(f"elements={missing_elements[:10]}")
+        if missing_genes:
+            details.append(f"genes={missing_genes[:10]}")
+        raise KeyError("pairs_to_test names were not loaded: " + "; ".join(details))
+    return np.asarray(
+        [(pert_lookup[element], gene_lookup[gene]) for element, gene in pair_frame.itertuples(index=False, name=None)],
+        dtype=np.int32,
+    )
+
+
 def _validate_cli_input_keys(
     data,
     *,
@@ -1422,6 +1488,7 @@ def load_controls(
     size_factor_key: str | None = None,
     library_size_key: str | None = None,
     gene_name_key: str | None = None,
+    selected_genes: list[str] | None = None,
     device: str | Any | None = None,
     cell_keep_mask: np.ndarray | None = None,
     clip_gene_expression_percentile: float | None = None,
@@ -1432,10 +1499,12 @@ def load_controls(
     batch_covariate: str | None = None,
     return_covariate_transform_state: bool = False,
     infer_control_guides: bool = False,
+    retain_perturbation_design: bool = True,
 ) -> PerTurboData | tuple[PerTurboData, CovariateTransformState | None]:
     print("[perturbo] Loading controls...")
     adata = _resolve_adata(data, modality_key)
     is_backed = getattr(adata, "isbacked", False)
+    gene_idx = _resolve_gene_subset_indices(adata, selected_genes, gene_name_key)
 
     # Compose all obs-level filters into a single integer index array before
     # touching adata.X.  Backed AnnData forbids "view of a view", so we must
@@ -1456,7 +1525,7 @@ def load_controls(
         pert_adata = _resolve_perturbation_modality(data, perturbation_modality_key)
         if working_obs_names is not None:
             pert_adata = pert_adata[working_obs_names]
-        pert_id = _to_dense(_get_layer_matrix(pert_adata, perturbation_layer))
+        pert_matrix = _get_layer_matrix(pert_adata, perturbation_layer)
         pert_names = _extract_pert_names(pert_adata)
         guide_to_element = None
         element_names = None
@@ -1477,10 +1546,17 @@ def load_controls(
             perturbation_modality_key=perturbation_modality_key,
         )
         if control_cols is not None:
-            mask = pert_id[:, control_cols].sum(axis=1) > 0
+            selected_matrix = pert_matrix[:, control_cols]
+            mask = np.asarray(selected_matrix.sum(axis=1)).reshape(-1) > 0
             obs_idx = obs_idx[mask]
-            pert_id = np.asarray(pert_id)[np.ix_(mask, control_cols)]
+            pert_id = _to_dense(selected_matrix[mask]) if retain_perturbation_design else np.zeros(mask.sum(), dtype=np.int32)
             pert_names = [n for n, c in zip(pert_names, control_cols) if c]
+        elif retain_perturbation_design:
+            pert_id = _to_dense(pert_matrix)
+        else:
+            pert_id = np.zeros(len(obs_idx), dtype=np.int32)
+        if not retain_perturbation_design:
+            pert_names = ["control"]
     else:
         if perturbation_key is None:
             raise ValueError("perturbation_key must be provided for obs-based perturbations.")
@@ -1496,7 +1572,7 @@ def load_controls(
         print(f"[perturbo] Subsampled controls to {max_control_cells} cells.")
 
     # Single slice: for backed data this is one targeted disk read.
-    adata = adata[obs_idx]
+    adata = adata[obs_idx, gene_idx]
     if is_backed:
         adata = adata.to_memory()
 
@@ -1569,6 +1645,7 @@ def load_analysis_cells(
     gene_name_key: str | None = None,
     device: str | Any | None = None,
     selected_perturbations: list[str] | None = None,
+    selected_genes: list[str] | None = None,
     cell_keep_mask: np.ndarray | None = None,
     clip_gene_expression_percentile: float | None = None,
     winsorize_gene_expression: bool = False,
@@ -1584,6 +1661,7 @@ def load_analysis_cells(
     print(f"[perturbo] Loading analysis cells{subset_suffix}...")
     adata = _resolve_adata(data, modality_key)
     is_backed = getattr(adata, "isbacked", False)
+    gene_idx = _resolve_gene_subset_indices(adata, selected_genes, gene_name_key)
 
     # Compose all obs-level filters into a single integer index array before
     # touching adata.X.  Backed AnnData forbids "view of a view", so we must
@@ -1607,7 +1685,14 @@ def load_analysis_cells(
         if retain_guide_structure:
             if perturbation_element_varm_key is None:
                 raise ValueError("retain_guide_structure requires perturbation_element_varm_key.")
-            guide_matrix, guide_names, pert_id, guide_to_element, pert_names = _load_guide_shared_perturbation_data(
+            (
+                guide_matrix,
+                guide_names,
+                pert_id,
+                guide_to_element,
+                pert_names,
+                selected_row_mask,
+            ) = _load_guide_shared_perturbation_data(
                 data,
                 perturbation_modality_key=perturbation_modality_key,
                 perturbation_layer=perturbation_layer,
@@ -1617,10 +1702,9 @@ def load_analysis_cells(
                 element_subset=selected_perturbations,
             )
             if selected_perturbations is not None:
-                mask = np.asarray(pert_id).sum(axis=1) > 0
-                obs_idx = obs_idx[mask]
-                pert_id = pert_id[mask]
-                guide_matrix = guide_matrix[mask]
+                if selected_row_mask is None:
+                    raise RuntimeError("Missing row mask for selected guide-aware perturbations.")
+                obs_idx = obs_idx[selected_row_mask]
         elif perturbation_element_varm_key is not None:
             pert_id, pert_names = _load_grouped_perturbation_matrix(
                 data,
@@ -1655,7 +1739,7 @@ def load_analysis_cells(
             obs_idx = obs_idx[mask]
 
     # Single slice: for backed data this is one targeted disk read.
-    adata = adata[obs_idx]
+    adata = adata[obs_idx, gene_idx]
     if is_backed:
         adata = adata.to_memory()
 
@@ -1750,6 +1834,11 @@ def fit_control(
     print("[perturbo] Fitting control model...")
     counts = data.counts
     pert_id = data.pert_id
+    # Stage 1 conditions beta to zero. Unless guide random effects are being
+    # estimated, perturbation identities cannot affect the likelihood and a
+    # high-MOI matrix would only trigger a large zero-valued matrix multiply.
+    if not guide_random_effects and getattr(pert_id, "ndim", None) == 2:
+        pert_id = jnp.zeros((counts.shape[0],), dtype=jnp.int32)
     num_perts = _infer_num_perts(pert_id)
     num_genes = counts.shape[1]
     if minibatch_size is not None and minibatch_size > counts.shape[0]:
@@ -1989,8 +2078,17 @@ def _summarize_stage2_guide_posteriors(
     if data.guide_to_element is None:
         return {}
     guide_to_element = np.asarray(data.guide_to_element, dtype=np.float32)
-    beta_loc = np.asarray(params["beta_auto_loc"], dtype=np.float32)
-    beta_scale = np.clip(np.asarray(params["beta_auto_scale"], dtype=np.float32), 1e-6, None)
+    beta_loc_raw = np.asarray(params["beta_auto_loc"], dtype=np.float32)
+    beta_scale_raw = np.clip(np.asarray(params["beta_auto_scale"], dtype=np.float32), 1e-6, None)
+    if data.effect_indices is None:
+        beta_loc = beta_loc_raw
+        beta_scale = beta_scale_raw
+    else:
+        indices = np.asarray(data.effect_indices, dtype=np.int32)
+        beta_loc = np.zeros((len(data.pert_names), len(data.gene_names)), dtype=np.float32)
+        beta_scale = np.zeros_like(beta_loc)
+        beta_loc[indices[:, 0], indices[:, 1]] = beta_loc_raw
+        beta_scale[indices[:, 0], indices[:, 1]] = beta_scale_raw
 
     if guide_effect_strategy == "shared":
         effect_mean = guide_to_element @ beta_loc
@@ -2009,8 +2107,8 @@ def _summarize_stage2_guide_posteriors(
 
     if element_block_size < 1:
         raise ValueError("element_block_size must be >= 1.")
-    beta_loc_jax = jnp.asarray(params["beta_auto_loc"])
-    beta_scale_jax = jnp.asarray(params["beta_auto_scale"])
+    beta_loc_jax = jnp.asarray(beta_loc)
+    beta_scale_jax = jnp.asarray(beta_scale)
     relative_loc = jnp.asarray(params["guide_relative_efficiency_auto_loc"])
     relative_scale = jnp.asarray(params["guide_relative_efficiency_auto_scale"])
     num_guides, num_genes = guide_to_element.shape[0], beta_loc.shape[1]
@@ -2081,6 +2179,19 @@ def fit_perturbation_effects(
     pert_id = data.pert_id
     num_perts = _infer_num_perts(pert_id)
     num_genes = counts.shape[1]
+    effect_indices = data.effect_indices
+    if effect_indices is not None:
+        effect_indices_np = np.asarray(effect_indices, dtype=np.int32)
+        if effect_indices_np.ndim != 2 or effect_indices_np.shape[1] != 2 or effect_indices_np.shape[0] == 0:
+            raise ValueError("effect_indices must have shape (n_pairs, 2) with at least one pair.")
+        if np.any(effect_indices_np[:, 0] < 0) or np.any(effect_indices_np[:, 0] >= num_perts):
+            raise ValueError("effect_indices contains an out-of-range perturbation index.")
+        if np.any(effect_indices_np[:, 1] < 0) or np.any(effect_indices_np[:, 1] >= num_genes):
+            raise ValueError("effect_indices contains an out-of-range gene index.")
+        if np.unique(effect_indices_np, axis=0).shape[0] != effect_indices_np.shape[0]:
+            raise ValueError("effect_indices must not contain duplicate pairs.")
+        if fit_perturbation_dispersion:
+            raise ValueError("Pair-restricted effects are not yet compatible with fit_perturbation_dispersion=True.")
     guide_effect_strategy, guide_activity_mode = _validate_guide_model_request(
         data,
         guide_effect_strategy=guide_effect_strategy,
@@ -2185,7 +2296,7 @@ def fit_perturbation_effects(
     )
     dispersion_kwargs = ({"fit_perturbation_dispersion": True, "perturbation_dispersion_prior_rate": perturbation_dispersion_prior_rate} if fit_perturbation_dispersion else {})
     init_values = {
-        "beta": jnp.zeros((num_perts, num_genes)),
+        "beta": jnp.zeros((num_perts, num_genes) if effect_indices is None else (int(effect_indices.shape[0]),)),
     }
     if guide_effect_strategy == "relative" and num_guides is not None:
         init_values["guide_relative_efficiency"] = jnp.full((num_guides, num_genes), 0.8, dtype=jnp.float32)
@@ -2280,6 +2391,7 @@ def fit_perturbation_effects(
             prior=prior,
             guide_matrix=data.guide_matrix if use_guide_shared_model else None,
             guide_to_element=data.guide_to_element if use_guide_shared_model else None,
+            effect_indices=effect_indices,
             guide_effect_strategy=guide_effect_strategy,
             guide_random_effects=random_effects_in_model,
             **dispersion_kwargs,
@@ -2306,14 +2418,23 @@ def fit_perturbation_effects(
             prior=prior,
             guide_matrix=data.guide_matrix if use_guide_shared_model else None,
             guide_to_element=data.guide_to_element if use_guide_shared_model else None,
+            effect_indices=effect_indices,
             guide_effect_strategy=guide_effect_strategy,
             guide_random_effects=random_effects_in_model,
             **dispersion_kwargs,
             **count_censoring_kwargs,
         )
 
-    loc = result.params["beta_auto_loc"]
-    scale = jnp.clip(result.params["beta_auto_scale"], 1e-6, None)
+    loc_raw = result.params["beta_auto_loc"]
+    scale_raw = jnp.clip(result.params["beta_auto_scale"], 1e-6, None)
+    if effect_indices is None:
+        loc = loc_raw
+        scale = scale_raw
+    else:
+        loc = jnp.full((num_perts, num_genes), jnp.nan, dtype=loc_raw.dtype)
+        scale = jnp.full((num_perts, num_genes), jnp.nan, dtype=scale_raw.dtype)
+        loc = loc.at[effect_indices[:, 0], effect_indices[:, 1]].set(loc_raw)
+        scale = scale.at[effect_indices[:, 0], effect_indices[:, 1]].set(scale_raw)
     if apply_scale_inflation_fallback:
         tau = jnp.asarray(control_fit.guide_random_effect_tau, dtype=scale.dtype)
         if tau.ndim != 1 or tau.shape[0] != num_genes:
@@ -2352,6 +2473,7 @@ def fit_perturbation_effects(
         guide_offset_scale=guide_summary.get("guide_offset_scale"),
         dispersion_excess_inverse=dispersion_excess_inverse,
         guide_dispersion_excess_inverse=guide_dispersion_excess_inverse,
+        effect_indices=effect_indices,
     )
 
 
@@ -2678,6 +2800,16 @@ def _subset_perturbo_data_for_chunk(
         guide_to_element_chunk = jnp.asarray(guide_to_element_chunk_full[guide_keep], dtype=jnp.float32)
         guide_names_chunk = [str(name) for keep, name in zip(guide_keep.tolist(), data.guide_names, strict=True) if keep]
 
+    effect_indices_chunk = None
+    if data.effect_indices is not None:
+        global_effect_indices = np.asarray(data.effect_indices, dtype=np.int32)
+        global_to_local = np.full((len(data.pert_names),), -1, dtype=np.int32)
+        global_to_local[chunk_indices] = np.arange(chunk_indices.size, dtype=np.int32)
+        keep_effect = global_to_local[global_effect_indices[:, 0]] >= 0
+        selected_effects = global_effect_indices[keep_effect].copy()
+        selected_effects[:, 0] = global_to_local[selected_effects[:, 0]]
+        effect_indices_chunk = jnp.asarray(selected_effects, dtype=jnp.int32)
+
     return PerTurboData(
         counts=counts_chunk,
         pert_id=pert_id_chunk,
@@ -2689,6 +2821,7 @@ def _subset_perturbo_data_for_chunk(
         guide_matrix=guide_matrix_chunk,
         guide_names=guide_names_chunk,
         guide_to_element=guide_to_element_chunk,
+        effect_indices=effect_indices_chunk,
         library_size_center_log_mean=data.library_size_center_log_mean,
     )
 

--- a/src/perturbo/inference.py
+++ b/src/perturbo/inference.py
@@ -465,6 +465,7 @@ class PerTurboModel:
             winsorize_gene_expression=self.winsorize_gene_expression,
             gene_outlier_threshold_floor=self.gene_outlier_threshold_floor,
             return_covariate_transform_state=True,
+            retain_perturbation_design=self.guide_random_effects,
         )
         if isinstance(controls, tuple):
             control_data, covariate_transform_state = controls
@@ -491,7 +492,14 @@ class PerTurboModel:
             winsorize_gene_expression=self.winsorize_gene_expression,
             gene_outlier_threshold_floor=self.gene_outlier_threshold_floor,
             covariate_transform_state=covariate_transform_state,
-            retain_guide_structure=self.setup.guide_by_element_key is not None,
+            retain_guide_structure=bool(
+                self.setup.guide_by_element_key is not None
+                and (
+                    self.guide_effect_strategy != "shared"
+                    or self.guide_random_effects
+                    or self.fit_perturbation_dispersion
+                )
+            ),
             library_size_center_log_mean=control_data.library_size_center_log_mean,
         )
         minibatch_size = batch_size if batch_size not in (None, 0) else None

--- a/src/perturbo/model.py
+++ b/src/perturbo/model.py
@@ -14,18 +14,20 @@ def create_plates(
     pert_id: jnp.ndarray | None,
     covariates: jnp.ndarray | None = None,
     guide_matrix: jnp.ndarray | None = None,
+    effect_indices: jnp.ndarray | None = None,
     num_cells: int | None = None,
     num_genes: int | None = None,
     num_perts: int | None = None,
     num_guides: int | None = None,
     num_factors: int | None = None,
     num_covariates: int | None = None,
+    num_effects: int | None = None,
     subsample_size: int | None = None,
     cell_idx: jnp.ndarray | None = None,
     **kwargs,
 ):
     del kwargs
-    Plates = namedtuple("Plates", ["cells", "genes", "perts", "guides", "factors", "covariates"])
+    Plates = namedtuple("Plates", ["cells", "genes", "perts", "guides", "factors", "covariates", "effects"])
     if counts is not None:
         inferred_cells, inferred_genes = counts.shape
         if num_cells is None:
@@ -36,6 +38,8 @@ def create_plates(
         num_perts = int(pert_id.shape[1])
     if num_guides is None and guide_matrix is not None and getattr(guide_matrix, "ndim", None) == 2:
         num_guides = int(guide_matrix.shape[1])
+    if num_effects is None and effect_indices is not None:
+        num_effects = int(effect_indices.shape[0])
     if num_factors is None:
         num_factors = 1
     if num_covariates is None and covariates is not None and getattr(covariates, "ndim", None) == 2:
@@ -49,6 +53,7 @@ def create_plates(
         plate("guides", int(num_guides) if num_guides is not None and int(num_guides) > 0 else 1, dim=-2),
         plate("factors", num_factors, dim=-3),
         covariate_plate,
+        plate("effects", int(num_effects) if num_effects is not None and int(num_effects) > 0 else 1, dim=-1),
     )
 
 
@@ -169,6 +174,7 @@ def BaseModel(
     covariates=None,
     guide_matrix=None,
     guide_to_element=None,
+    effect_indices=None,
     num_cells=None,
     num_genes=None,
     num_perts=None,
@@ -196,6 +202,7 @@ def BaseModel(
         num_perts=num_perts,
         num_guides=num_guides,
         num_factors=num_factors,
+        num_effects=None if effect_indices is None else int(effect_indices.shape[0]),
         subsample_size=subsample_size,
         cell_idx=cell_idx,
     )
@@ -205,6 +212,7 @@ def BaseModel(
     guide_plate = plates.guides
     factor_plate = plates.factors
     covariate_plate = plates.covariates
+    effect_plate = plates.effects
     full_num_cells = int(num_cells) if num_cells is not None else (int(counts.shape[0]) if counts is not None else None)
     uses_mixture_nb = likelihood in {"mixture_nb"}
 
@@ -247,12 +255,27 @@ def BaseModel(
         if uses_mixture_nb:
             theta_outlier = numpyro.sample("theta_outlier", dist.LogNormal(0.0, 2.0))
             outlier_mean_shift = numpyro.sample("outlier_mean_shift", dist.HalfNormal(1.0))
-        with pert_plate:
-            beta = _sample_effect_site("beta", prior)
-            if fit_perturbation_dispersion:
-                dispersion_excess_inverse = numpyro.sample(
-                    "dispersion_excess_inverse", dist.Exponential(perturbation_dispersion_prior_rate)
-                )
+        if effect_indices is None:
+            with pert_plate:
+                beta = _sample_effect_site("beta", prior)
+                if fit_perturbation_dispersion:
+                    dispersion_excess_inverse = numpyro.sample(
+                        "dispersion_excess_inverse", dist.Exponential(perturbation_dispersion_prior_rate)
+                    )
+
+    if effect_indices is not None:
+        if fit_perturbation_dispersion:
+            raise ValueError("Pair-restricted effects are not yet compatible with fitted perturbation dispersion.")
+        effect_indices = jnp.asarray(effect_indices, dtype=jnp.int32)
+        with effect_plate:
+            beta_values = _sample_effect_site("beta", prior)
+        # Keep the variational parameterization restricted to the requested
+        # pairs, but assemble a dense matrix for the downstream matmul.  The
+        # perturbation-by-gene map is small even in high-MOI screens (e.g.
+        # 431 x 381 in Gasperini), while JAX's CPU BCOO matmul becomes much
+        # slower once a control is tested against many genes.
+        beta = jnp.zeros((int(num_perts), int(num_genes)), dtype=beta_values.dtype)
+        beta = beta.at[effect_indices[:, 0], effect_indices[:, 1]].set(beta_values)
 
     covariate_coef = None
     if covariates is not None:
@@ -349,6 +372,7 @@ def GuideSharedEffectModel(
     covariates=None,
     guide_matrix=None,
     guide_to_element=None,
+    effect_indices=None,
     num_cells=None,
     num_genes=None,
     num_perts=None,
@@ -378,6 +402,7 @@ def GuideSharedEffectModel(
         num_perts=num_perts,
         num_guides=num_guides,
         num_factors=num_factors,
+        num_effects=None if effect_indices is None else int(effect_indices.shape[0]),
         subsample_size=subsample_size,
         cell_idx=cell_idx,
     )
@@ -387,6 +412,7 @@ def GuideSharedEffectModel(
     guide_plate = plates.guides
     factor_plate = plates.factors
     covariate_plate = plates.covariates
+    effect_plate = plates.effects
     full_num_cells = int(num_cells) if num_cells is not None else (int(counts.shape[0]) if counts is not None else None)
     uses_mixture_nb = likelihood in {"mixture_nb"}
 
@@ -429,13 +455,25 @@ def GuideSharedEffectModel(
         if uses_mixture_nb:
             theta_outlier = numpyro.sample("theta_outlier", dist.LogNormal(0.0, 2.0))
             outlier_mean_shift = numpyro.sample("outlier_mean_shift", dist.HalfNormal(1.0))
-        with pert_plate:
-            beta = _sample_effect_site("beta", prior)
+        if effect_indices is None:
+            with pert_plate:
+                beta = _sample_effect_site("beta", prior)
         if fit_perturbation_dispersion:
             with guide_plate:
                 guide_dispersion_excess_inverse = numpyro.sample(
                     "guide_dispersion_excess_inverse", dist.Exponential(perturbation_dispersion_prior_rate)
                 )
+
+    if effect_indices is not None:
+        if fit_perturbation_dispersion:
+            raise ValueError("Pair-restricted effects are not yet compatible with fitted perturbation dispersion.")
+        effect_indices = jnp.asarray(effect_indices, dtype=jnp.int32)
+        with effect_plate:
+            beta_values = _sample_effect_site("beta", prior)
+        # As above, only requested pairs are parameters; materializing the
+        # compact perturbation-by-gene map makes high-MOI dense matmul fast.
+        beta = jnp.zeros((int(num_perts), int(num_genes)), dtype=beta_values.dtype)
+        beta = beta.at[effect_indices[:, 0], effect_indices[:, 1]].set(beta_values)
 
     covariate_coef = None
     if covariates is not None:

--- a/tests/test_api_workflow.py
+++ b/tests/test_api_workflow.py
@@ -201,6 +201,34 @@ def test_two_stage_fit_with_baseline_uncertainty_marginalization() -> None:
     assert jnp.all(jnp.isfinite(beta_fit.posterior_scale))
 
 
+def test_pair_restricted_fit_has_one_variational_parameter_per_pair() -> None:
+    counts = jnp.array(
+        [[0, 1, 0], [2, 0, 1], [0, 0, 3], [1, 0, 0]],
+        dtype=jnp.int32,
+    )
+    data = PerTurboData(
+        counts=counts,
+        pert_id=jnp.array([0, 1, 0, 1], dtype=jnp.int32),
+        pert_names=["ctrl", "pert"],
+        gene_names=["g1", "g2", "g3"],
+        effect_indices=jnp.array([[0, 1], [1, 2]], dtype=jnp.int32),
+    )
+    control_fit = fit_control(data, num_steps=2, model_name="negbin", minibatch_size=2)
+    beta_fit = fit_perturbation_effects(
+        data,
+        control_fit,
+        num_steps=2,
+        model_name="negbin",
+        minibatch_size=2,
+    )
+
+    assert beta_fit.effect_indices.shape == (2, 2)
+    assert int(jnp.isfinite(beta_fit.posterior_mean).sum()) == 2
+    assert int(jnp.isfinite(beta_fit.posterior_scale).sum()) == 2
+    assert jnp.isnan(beta_fit.posterior_mean[0, 0])
+    assert jnp.isfinite(beta_fit.posterior_mean[0, 1])
+
+
 def test_two_stage_fit_supports_mixture_nb() -> None:
     counts = jnp.array(
         [

--- a/tests/test_high_moi.py
+++ b/tests/test_high_moi.py
@@ -229,6 +229,21 @@ def test_load_controls_high_moi_defaults_to_all_rows() -> None:
     assert controls.pert_names == ["pertA", "pertB", "pertC"]
 
 
+def test_load_controls_can_discard_unused_high_moi_design() -> None:
+    data = _make_mudata()
+    controls = load_controls(
+        data,
+        perturbation_key=None,
+        control_selector=None,
+        modality_key="rna",
+        perturbation_modality_key="pert",
+        retain_perturbation_design=False,
+    )
+    assert controls.pert_id.shape == (4,)
+    assert np.array_equal(np.asarray(controls.pert_id), np.zeros(4, dtype=np.int32))
+    assert controls.pert_names == ["control"]
+
+
 def test_load_analysis_cells_high_moi_subset_filters_cells() -> None:
     data = _make_mudata()
     analysis_data = load_analysis_cells(
@@ -257,6 +272,30 @@ def test_load_analysis_cells_high_moi_subset_filters_cells() -> None:
             [
                 [2, 0, 1],
                 [0, 0, 3],
+            ],
+            dtype=np.int32,
+        ),
+    )
+
+
+def test_load_analysis_cells_subsets_gene_union_before_jax_transfer() -> None:
+    data = _make_mudata()
+    analysis_data = load_analysis_cells(
+        data,
+        perturbation_key=None,
+        modality_key="rna",
+        perturbation_modality_key="pert",
+        selected_perturbations=["pertA"],
+        selected_genes=["g3", "g1"],
+    )
+    assert analysis_data.gene_names == ["g3", "g1"]
+    assert analysis_data.counts.shape == (2, 2)
+    assert np.array_equal(
+        np.asarray(analysis_data.counts),
+        np.array(
+            [
+                [1, 2],
+                [3, 0],
             ],
             dtype=np.int32,
         ),

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -83,6 +83,24 @@ def test_negbin_model_runs_one_step() -> None:
     )
 
 
+def test_pair_restricted_model_samples_only_requested_coefficients() -> None:
+    counts, pert_id = _make_toy_data()
+    effect_indices = jnp.array([[0, 1], [1, 2]], dtype=jnp.int32)
+    trace = numpyro.handlers.trace(
+        numpyro.handlers.seed(NegBinModel, jax.random.PRNGKey(0))
+    ).get_trace(
+        counts,
+        pert_id,
+        effect_indices=effect_indices,
+        num_cells=counts.shape[0],
+        num_genes=counts.shape[1],
+        num_perts=2,
+    )
+
+    assert trace["beta"]["value"].shape == (2,)
+    assert trace["obs"]["value"].shape == counts.shape
+
+
 def test_negbin_model_uses_negative_binomial_observation() -> None:
     counts, pert_id = _make_toy_data()
     trace = _trace_model(NegBinModel, counts, pert_id)

--- a/tests/test_pair_restriction.py
+++ b/tests/test_pair_restriction.py
@@ -1,0 +1,48 @@
+"""Tests for exact element/gene pair restriction."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from perturbo.cli import _load_pairs_to_test
+from perturbo.core import build_effect_indices
+
+
+def test_load_pairs_to_test_accepts_tsv_and_deduplicates(tmp_path) -> None:
+    path = tmp_path / "cis_pairs.tsv"
+    pd.DataFrame(
+        {
+            "element": ["e1", "e1", "e2"],
+            "gene": ["g2", "g2", "g1"],
+            "distance": [10, 10, 20],
+        }
+    ).to_csv(path, sep="\t", index=False)
+
+    pairs = _load_pairs_to_test(path)
+
+    assert pairs.to_dict("records") == [
+        {"element": "e1", "gene": "g2"},
+        {"element": "e2", "gene": "g1"},
+    ]
+
+
+def test_build_effect_indices_preserves_exact_pairs_not_cartesian_product() -> None:
+    pairs = pd.DataFrame({"element": ["e1", "e2"], "gene": ["g2", "g1"]})
+
+    indices = build_effect_indices(
+        pairs,
+        pert_names=["e1", "e2"],
+        gene_names=["g1", "g2"],
+    )
+
+    np.testing.assert_array_equal(indices, np.array([[0, 1], [1, 0]], dtype=np.int32))
+    assert indices.shape[0] == 2
+
+
+def test_build_effect_indices_reports_missing_names() -> None:
+    pairs = pd.DataFrame({"element": ["missing"], "gene": ["g1"]})
+
+    with pytest.raises(KeyError, match="elements=.*missing"):
+        build_effect_indices(pairs, pert_names=["e1"], gene_names=["g1"])


### PR DESCRIPTION
## Summary
- add exact pair-restricted fitting via `--pairs-to-test`
- avoid unnecessary high-MOI guide-matrix retention for shared effects
- compile minibatched SVI updates with `lax.scan`
- assemble restricted beta parameters into dense matrices for fast high-MOI GEMMs
- add coverage for pair restriction and high-MOI workflows

## Validation
- targeted pair/high-MOI/API tests pass
- full non-fitted-workflow test suite passes
- Gasperini TSS/NTC pilot completed successfully
- Docker workflow dispatched separately on this branch