### PR TITLE
Fix chunked inference correctness and bound analysis memory

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,9 +2,9 @@ name: Check build
 
 on:
   push:
-    branches: [main]
+    branches: [main, v2-port]
   pull_request:
-    branches: [main]
+    branches: [main, v2-port]
 
 jobs:
   package:
@@ -16,7 +16,7 @@ jobs:
           python-version: "3.11"
       - uses: astral-sh/setup-uv@v5
       - run: uv build
-      - run: uv run --with twine twine check --strict dist/*
+      - run: uv run --with "twine>=7" twine check --strict dist/*
       - run: uv venv /tmp/perturbo-wheel
       - run: uv pip install --python /tmp/perturbo-wheel/bin/python dist/*.whl
       - run: /tmp/perturbo-wheel/bin/perturbo --help

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -7,7 +7,7 @@ on:
     # The v2 integration branch republishes the MUTABLE :v2-dev tag on every
     # commit, so downstream pipelines can track fixes by re-pulling one stable
     # name instead of editing a pinned sha into their config per attempt.
-    branches: ["feature/cortado-successor"]
+    branches: ["v2-port"]
   # Build and smoke-test (never push) on any PR that can change what lands in
   # the image. A broken image previously shipped because nothing exercised it
   # until after the release tag was cut.

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,9 +2,9 @@ name: Test
 
 on:
   push:
-    branches: [main]
+    branches: [main, v2-port]
   pull_request:
-    branches: [main]
+    branches: [main, v2-port]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,25 @@ and this project adheres to [Semantic Versioning][].
 -   Grouping guides into elements is a sparse product. The dense int8 product had
     no BLAS kernel and ran for hours on one core on a 233,000-cell screen before
     anything reached the GPU.
+-   High-MOI CLI chunking retains co-occurring predictors by fitting gene blocks
+    instead of dropping other perturbation columns. Sparse assignments remain
+    compact through loading and cell minibatching.
+-   Propensity fits remove dependent covariates without introducing arbitrary QR
+    directions. Each low-MOI target uses its own target-plus-control population,
+    with name-stable resampling keys across chunks.
+-   Baseline diagnostics form count-dependent arrays in gene blocks; all-cells
+    CRT gene blocks reuse the same compact propensity fit and receive one global
+    multiple-testing correction.
+-   Observed size factors preserve zero-count cells and full-panel centering.
+    Simulation bundles retain the fitted offsets and all chunked guide posterior
+    fields; fixed-zero offsets remain distinct from counts-derived offsets.
+-   Shared element means no longer count duplicate guides twice when perturbation
+    dispersion is enabled. Mixture-NB simulation leaves the outlier component
+    independent of the perturbation mean, matching the fitted likelihood.
+-   Log-normal NB quadrature uses log weights, and sampling applies the requested
+    sample shape once.
+-   Release tests and build checks run for `v2-port`; package validation supports
+    the build backend's metadata version.
 -   The float32 pin read the variational parameters through their constraints and
     handed them back to the optimizer unconstrained, so every positive scale
     restarted at exp of its value and stage one began 40% above its reference

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ perturbo --input screen.h5mu --out-dir perturbo_outputs/run --modality-key rna \
 The conditional randomization test runs alongside the Bayesian effect estimates
 by default (`--no-crt` opts out). It asks whether a gene's expression differs by more than it would had
 the guide landed in a different set of cells with the same covariates, and it
-evaluates that null in closed form rather than by resampling, so a genome-scale
+approximates its tail with a saddlepoint calculation without resampling, so a genome-scale
 screen can be tested against every gene:
 
 ```bash
@@ -82,6 +82,38 @@ control guides and warns when they are fewer than 1,000 or under 1%. A
 low-MOI screen may arrive with a guide-to-element map; the control-anchored
 test collapses the assignment to elements and sets aside cells carrying more
 than one, reporting the count. See `docs/crt_quickstart.md`.
+
+### Memory and chunking
+
+Use `--backed` for files larger than memory. For mutually exclusive assignments,
+perturbation chunks reduce both the number of cells and the number of fitted
+effects. Splitting co-occurring perturbations would omit predictors and can bias
+effects; when these assignments trigger automatic chunking, the CLI instead
+loads 256 genes at a time and retains every cell and predictor. Set
+`--gene-chunk-size 128` to choose a smaller block explicitly.
+
+Gene blocks currently support the plain NB model with observed or fixed-zero
+size factors, shared guide effects, no latent factors, no guide random effects,
+and no perturbation dispersion or baseline uncertainty propagation. Full-panel
+library sizes and the control centering are preserved across blocks. The
+all-cells CRT reuses its propensity fit, and multiple-testing correction happens
+once over the full tested family. Stage-two SVI defaults to 1,024 cells per step
+on this path; use `--minibatch-size-betas` and `--num-epochs-betas` to control
+training coverage. Stochastic fits at different block widths need not be
+numerically identical after a finite number of steps.
+
+For either chunking strategy, compare effect estimates with a longer training
+budget. The default 500 steps can underestimate strong knockdowns; CRT baseline
+polishing does not establish convergence of the Bayesian effect estimates.
+
+Gene blocks bound the count and likelihood buffers, but control fitting still
+loads up to `--max-control-cells` across all genes, and the final effect and CRT
+tables scale as perturbations × genes. A full atlas is therefore a cluster job.
+For a laptop smoke test, load a raw-count AnnData with `backed="r"`, select
+controls and a few perturbations, save full-panel cell totals in an observation
+column, then select a few hundred genes and pass that column with
+`--library-size-key`. A small debug run checks execution, not full-scale speed,
+convergence, or statistical calibration.
 
 ### Reporting a subset of pairs
 

--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ docker run --rm --gpus all perturbo:local --help
 The image uses JAX's CUDA 12 pip wheels, so the host must provide the NVIDIA
 Container Toolkit and a Linux NVIDIA driver version 525 or newer. Do not set
 `LD_LIBRARY_PATH` in the container: JAX uses its pip-installed CUDA libraries.
-The established GitHub Actions recipe builds the `linux/amd64` image and
-publishes it to GHCR only for version tags (or an explicit manual dispatch).
+GitHub Actions builds the `linux/amd64` image. Version tags publish releases;
+pushes to `v2-port` refresh the mutable `v2-dev` tag, and manual dispatches can
+also publish. Pull requests build and smoke-test the image without publishing.
 
 ## Quick start
 

--- a/docs/crt_quickstart.md
+++ b/docs/crt_quickstart.md
@@ -20,23 +20,27 @@ cell's probability of carrying the perturbation given its covariates. Because
 that distribution is a sum of independent Bernoulli terms, its cumulant
 generating function is exact and the tail probability is evaluated with a
 saddlepoint approximation instead of resampling. No resamples are drawn, the
-p-values reach far below what any permutation count could resolve, and a
-transcriptome-wide screen finishes in minutes on one GPU.
+p-values can reach below the resolution of a finite resampling run. Runtime
+depends on the screen, covariates, and hardware; the cumulant generating
+function is exact under the fitted Bernoulli law, but its saddlepoint tail is
+an approximation. Estimating that law from data does not give an automatic
+finite-sample calibration guarantee.
 
 Two properties matter for interpretation:
 
 - The null is fit on the baseline and reused, never refit per pair. Stage one
   of perturbo's two-stage model supplies it; the CRT then moves the nuisance
-  coefficients onto the exact null mode by Fisher scoring
+  coefficients toward the null mode by Fisher scoring
   (`--crt-polish-baseline`, on by default; always on for the all-cells design). The polish is what makes the test insensitive to how long stage one trained: measured on the simulation, the null false-positive rate and the power are unchanged from 100 stage-one steps to 2,500.
-- The statistic is a score test at the null. It is calibrated and matches
-  SCEPTRE's power, but a Wald test that refits the alternative (an NB GLM) can
-  be two to four points more powerful when many guides of mixed efficacy share
-  an element. That is the price of an exact null.
+- The statistic is a score test at the null. Calibration and power depend on
+  the assignment model, covariates, and screen design. Compare negative-control
+  and label-shuffled results, including the far tail used for discoveries;
+  agreement near p=0.05 alone does not establish calibration at 1e-5.
 
 ## Which design
 
-Nothing in the package measures MOI; you choose the pool.
+The CLI measures guide multiplicity for `--crt-pool auto`; an explicit pool
+overrides that choice.
 
 | | Control-anchored (low MOI) | All cells (high MOI) |
 |---|---|---|
@@ -187,9 +191,14 @@ Flags worth knowing:
   digits reported) and the CRT chunks run 4.3x faster. Adding a continuous
   covariate beside the batch returns to the dense path. There is no flag: the
   choice follows the nuisance design.
-- `--crt-gene-chunk-size` bounds memory on wide panels; results do not depend
-  on it. Perturbation chunking (`--max-chunk-size`) never changes a target's
-  p-value either, because resamples are keyed on the target's name.
+- `--crt-gene-chunk-size` bounds the inner CRT gene calculation. Use
+  `--gene-chunk-size` to also bound the analysis counts loaded from disk and
+  stage-two fitting. Co-occurring assignments use gene blocks when the CLI
+  would otherwise split perturbations, preserving the joint effect model.
+  The all-cells propensity fit is shared across gene blocks, and BH correction
+  happens after all blocks. In the control-anchored test, each propensity model
+  uses only its own target-plus-control pool and resamples are keyed by target
+  name, so unrelated targets in a perturbation chunk do not change its test.
 - Supported configuration is deliberately narrow: plain negative-binomial
   likelihood, observed or fixed size factors, no latent factors, no guide
   random effects. Latent size factors are refused because a per-cell offset fit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ dev = [
     "build>=1.2",
     "pre-commit>=4.0",
     "ruff>=0.8",
-    "twine>=6.0",
+    "twine>=7.0",
 ]
 
 [tool.uv]

--- a/src/perturbo/_internal/high_moi/resampling.py
+++ b/src/perturbo/_internal/high_moi/resampling.py
@@ -156,6 +156,129 @@ def _logistic_irls_orthonormal(
     return coef
 
 
+@partial(jax.jit, static_argnames=("max_iterations",))
+def _logistic_irls_masked_orthonormal(
+    indicators: jnp.ndarray,
+    inclusion: jnp.ndarray,
+    basis: jnp.ndarray,
+    jitter: jnp.ndarray,
+    eta_clip: jnp.ndarray,
+    *,
+    max_iterations: int,
+) -> jnp.ndarray:
+    """Batched IRLS where each response is fit on its own subset of rows."""
+
+    num_features = basis.shape[1]
+    eye = jnp.eye(num_features, dtype=basis.dtype)
+
+    def step(coef, _):
+        probability = jax.nn.sigmoid(jnp.clip(coef @ basis.T, -eta_clip, eta_clip))
+        weight = jnp.clip(probability * (1.0 - probability), 1e-9, None) * inclusion
+        gradient = ((indicators - probability) * inclusion) @ basis
+        curvature = jnp.einsum("nk,en,nl->ekl", basis, weight, basis) + jitter * eye
+        return coef + jnp.linalg.solve(curvature, gradient[..., None])[..., 0], None
+
+    coef, _ = jax.lax.scan(
+        step,
+        jnp.zeros((indicators.shape[0], num_features), dtype=basis.dtype),
+        None,
+        length=max_iterations,
+    )
+    return coef
+
+
+def _rank_revealing_basis(design: np.ndarray | jnp.ndarray) -> jnp.ndarray:
+    """An orthonormal basis for exactly the numerical column space of ``design``.
+
+    A reduced, unpivoted QR always returns one column per input column.  When
+    the design contains a zero or dependent column, the extra columns of Q are
+    an arbitrary completion outside the supplied design's span.  Feeding those
+    columns to the propensity GLM therefore adds predictors the caller never
+    supplied.
+
+    Normalize nonzero columns before the SVD so changing a covariate's units
+    cannot change the numerical rank decision.  The tolerance is the standard
+    LAPACK-style relative threshold, stated explicitly here because the fitted
+    assignment law must not depend on a library default.  The host-side SVD is
+    intentional: this small ``cells x covariates`` decomposition is performed
+    once per propensity design, while the large batched IRLS remains on JAX.
+    """
+
+    raw = np.asarray(design)
+    source_epsilon = (
+        np.finfo(raw.dtype).eps if np.issubdtype(raw.dtype, np.floating) else np.finfo(np.float64).eps
+    )
+    matrix = np.asarray(raw, dtype=np.float64)
+    if matrix.ndim != 2:
+        raise ValueError("design must be a two-dimensional matrix.")
+    if not np.isfinite(matrix).all():
+        raise ValueError("design must contain only finite values.")
+    if matrix.shape[0] == 0:
+        raise ValueError("design must contain at least one row.")
+
+    norms = np.linalg.norm(matrix, axis=0)
+    nonzero = norms > 0.0
+    if not np.any(nonzero):
+        return jnp.zeros((matrix.shape[0], 0), dtype=jnp.float32)
+    scaled = matrix[:, nonzero] / norms[nonzero]
+    left, singular_values, _ = np.linalg.svd(scaled, full_matrices=False)
+    if singular_values.size == 0:
+        rank = 0
+    else:
+        # The decomposition itself runs in float64, so its usual LAPACK bound
+        # scales with the row count. Source quantization is different: after
+        # column normalization its perturbation grows with the number of
+        # columns, not with the number of observations. Multiplying float32
+        # epsilon by ``n_rows`` would make the rank tolerance approach one on
+        # million-cell screens and discard ordinary correlated covariates.
+        tolerance = max(
+            max(scaled.shape) * np.finfo(np.float64).eps,
+            8.0 * np.sqrt(scaled.shape[1]) * source_epsilon,
+        ) * float(singular_values[0])
+        rank = int(np.count_nonzero(singular_values > tolerance))
+    return jnp.asarray(left[:, :rank], dtype=jnp.float32)
+
+
+def propensity_basis(design: np.ndarray | jnp.ndarray) -> jnp.ndarray:
+    """Return the rank-revealing propensity basis used by the fitters."""
+
+    return _rank_revealing_basis(design)
+
+
+def fit_masked_propensity_coefficients(
+    indicators: np.ndarray | jnp.ndarray,
+    inclusion: np.ndarray | jnp.ndarray,
+    basis: np.ndarray | jnp.ndarray,
+    *,
+    max_iterations: int = 25,
+    jitter: float = 1e-6,
+    eta_clip: float = 30.0,
+) -> jnp.ndarray:
+    """Fit several logistic models on row subsets in one shared basis.
+
+    ``indicators`` and ``inclusion`` are both ``(models, cells)``. Rows where
+    ``inclusion`` is zero contribute neither score nor curvature. This is used
+    by the low-MOI CRT to fit each target only against its own valid pool while
+    retaining a compact common basis for the saddlepoint calculation.
+    """
+
+    y = jnp.atleast_2d(jnp.asarray(indicators, dtype=jnp.float32))
+    mask = jnp.atleast_2d(jnp.asarray(inclusion, dtype=jnp.float32))
+    Q = jnp.asarray(basis, dtype=jnp.float32)
+    if y.shape != mask.shape:
+        raise ValueError("indicators and inclusion must have the same shape.")
+    if y.shape[1] != Q.shape[0]:
+        raise ValueError("indicators and basis disagree on the cell count.")
+    return _logistic_irls_masked_orthonormal(
+        y,
+        mask,
+        Q,
+        jnp.asarray(jitter, dtype=jnp.float32),
+        jnp.asarray(eta_clip, dtype=jnp.float32),
+        max_iterations=max_iterations,
+    )
+
+
 def fit_propensity_probabilities(
     indicators: np.ndarray | jnp.ndarray,
     design: np.ndarray | jnp.ndarray,
@@ -173,11 +296,13 @@ def fit_propensity_probabilities(
     equation is what makes ``sum(p)`` reproduce the observed selected count,
     and a penalty would quietly break it.
 
-    The fit runs in an orthonormal basis for the design's column space, taken
-    by QR. Fitted probabilities are invariant to any full-rank linear
+    The fit runs in a rank-revealing orthonormal basis for the design's column
+    space. Fitted probabilities are invariant to any full-rank linear
     reparameterization, so this changes nothing statistically while making
     ``Q'WQ`` well conditioned - which is what lets the whole thing run in
-    float32 without the Hessian solve degrading.
+    float32 without the Hessian solve degrading. Zero and dependent columns
+    are removed from the basis rather than letting a QR completion invent
+    directions outside the supplied design.
 
     ``eta_clip`` bounds the linear predictor, standing in for the step-halving
     a production GLM routine does; without it a separable element sends the
@@ -232,6 +357,7 @@ def fit_propensity_coefficients(
     max_iterations: int = 25,
     jitter: float = 1e-6,
     eta_clip: float = 30.0,
+    basis: np.ndarray | jnp.ndarray | None = None,
 ) -> tuple[jnp.ndarray, jnp.ndarray]:
     """The same fits, returned as ``(coefficients, basis)`` in an orthonormal basis.
 
@@ -257,7 +383,9 @@ def fit_propensity_coefficients(
     Z = jnp.asarray(design, dtype=jnp.float32)
     if y.shape[1] != Z.shape[0]:
         raise ValueError("indicators and design disagree on the cell count.")
-    basis, _ = jnp.linalg.qr(Z)
+    basis = _rank_revealing_basis(Z) if basis is None else jnp.asarray(basis, dtype=jnp.float32)
+    if basis.ndim != 2 or basis.shape[0] != Z.shape[0]:
+        raise ValueError("basis must have shape (cells, rank).")
     coefficients = _logistic_irls_orthonormal(
         y,
         basis,

--- a/src/perturbo/_internal/saddlepoint.py
+++ b/src/perturbo/_internal/saddlepoint.py
@@ -1407,8 +1407,10 @@ def fit_low_moi_propensity_saddlepoint(
     contribution: np.ndarray,
     target_codes: np.ndarray,
     control_mask: np.ndarray,
-    shared_logits: np.ndarray,
-    intercepts: np.ndarray,
+    shared_logits: np.ndarray | None = None,
+    intercepts: np.ndarray | None = None,
+    propensity_coefficients: np.ndarray | None = None,
+    propensity_basis: np.ndarray | None = None,
     num_targets: int,
     screen_p_value: float = 0.05,
     two_sided: str = "equal-tail",
@@ -1460,19 +1462,18 @@ def fit_low_moi_propensity_saddlepoint(
     CGF below *is* the resampling law, so the field is filled with zeros and
     the only remaining error is the Lugannani-Rice asymptotic.
 
-    The selection model arrives decomposed - ``shared_logits`` per cell and an
-    ``intercepts`` entry per target, NaN where a target has no pool - because
-    that decomposition is what lets every target be screened at once. The
-    controls are common to every pool, so the three null cumulants over them
-    are three matmuls of a ``(targets, controls)`` weight matrix against the
-    control contributions, and the few cells a target adds arrive by segment
-    sum. Candidates the screen promotes are then packed across targets into
-    blocks of ``gene_block_size`` (target, gene) pairs, each column carrying
-    its own target's logits, so the block count is ``ceil(candidates / B)``
-    rather than one block per target per chunk. Per pair this is the same
-    pool, the same logits and the same kernel as evaluating targets one at a
-    time; only the order of the pool rows differs (controls first, then the
-    target's own cells), which is floating-point rounding, not arithmetic.
+    The preferred selection model arrives as target-specific
+    ``propensity_coefficients`` in one rank-revealing ``propensity_basis``.
+    Each target's coefficients were fitted on controls plus only its own cells,
+    making its assignment law independent of unrelated targets sharing a CLI
+    chunk. The legacy ``shared_logits`` plus ``intercepts`` representation is
+    still accepted for direct callers and old cached objects.
+
+    Both representations let every target be screened in bounded batches. The
+    controls are common to every pool, so their null cumulants are matrix
+    products against the control contributions, and the few cells a target
+    adds arrive by segment sum. Candidates the screen promotes are then packed
+    across targets into blocks of ``gene_block_size`` (target, gene) pairs.
     """
     _check_two_sided(two_sided)
 
@@ -1496,36 +1497,80 @@ def fit_low_moi_propensity_saddlepoint(
 
     codes = np.asarray(target_codes, dtype=np.int64).reshape(-1)
     control = np.asarray(control_mask, dtype=bool).reshape(-1)
-    shared = np.asarray(shared_logits, dtype=np.float64).reshape(-1)
-    alpha = np.asarray(intercepts, dtype=np.float64).reshape(-1)
-    if codes.shape != (num_cells,) or control.shape != (num_cells,) or shared.shape != (num_cells,):
-        raise ValueError("target_codes, control_mask and shared_logits must have one entry per cell.")
-    if alpha.shape != (num_targets,):
-        raise ValueError("intercepts must have one entry per target.")
+    compact_given = propensity_coefficients is not None or propensity_basis is not None
+    legacy_given = shared_logits is not None or intercepts is not None
+    if compact_given and legacy_given:
+        raise ValueError(
+            "Pass either propensity_coefficients with propensity_basis or "
+            "shared_logits with intercepts, not both."
+        )
+    if compact_given:
+        if propensity_coefficients is None or propensity_basis is None:
+            raise ValueError("propensity_coefficients and propensity_basis must be passed together.")
+        coefficients = np.asarray(propensity_coefficients, dtype=np.float64)
+        basis = np.asarray(propensity_basis, dtype=np.float64)
+        if coefficients.ndim != 2 or coefficients.shape[0] != num_targets:
+            raise ValueError("propensity_coefficients must have shape (targets, basis).")
+        if basis.shape != (num_cells, coefficients.shape[1]):
+            raise ValueError("propensity_basis must have shape (cells, basis).")
+        coefficients_device = jnp.asarray(coefficients)
+        basis_device = jnp.asarray(basis)
+        shared = None
+        alpha = None
+    else:
+        if shared_logits is None or intercepts is None:
+            raise ValueError(
+                "Pass propensity_coefficients with propensity_basis, or shared_logits with intercepts."
+            )
+        shared = np.asarray(shared_logits, dtype=np.float64).reshape(-1)
+        alpha = np.asarray(intercepts, dtype=np.float64).reshape(-1)
+        if shared.shape != (num_cells,):
+            raise ValueError("shared_logits must have one entry per cell.")
+        if alpha.shape != (num_targets,):
+            raise ValueError("intercepts must have one entry per target.")
+        coefficients_device = None
+        basis_device = None
+    if codes.shape != (num_cells,) or control.shape != (num_cells,):
+        raise ValueError("target_codes and control_mask must have one entry per cell.")
     if codes.max(initial=-1) >= num_targets:
         raise ValueError("target_codes index beyond num_targets.")
 
     shape = (num_targets, num_genes)
-    target_valid = np.isfinite(alpha)
-    # A target with a pool but no cells of its own has no observed sum to test.
-    target_valid &= np.bincount(codes[codes >= 0], minlength=num_targets) > 0
-    alpha_safe = np.where(target_valid, alpha, 0.0)
-    alpha_device = jnp.asarray(alpha_safe)
+    selected_counts = np.bincount(codes[codes >= 0], minlength=num_targets)
+    own = (codes >= 0) & ~control
+    own_rows = np.flatnonzero(own)
+    own_codes = codes[own_rows]
+    pool_counts = int(np.count_nonzero(control)) + np.bincount(
+        own_codes, minlength=num_targets
+    )
+    target_valid = (selected_counts > 0) & (selected_counts < pool_counts)
+    if compact_given:
+        target_valid &= np.isfinite(coefficients).all(axis=1)
+        alpha_device = None
+    else:
+        target_valid &= np.isfinite(alpha)
+        alpha_safe = np.where(target_valid, alpha, 0.0)
+        alpha_device = jnp.asarray(alpha_safe)
 
     # The pool of target t is the controls plus t's own cells. A cell can be
     # both (a control that also carries the target's code); it then enters the
     # pool once, through the control block, and the observed sum still counts
     # it, exactly as the per-target construction did.
     control_rows = np.flatnonzero(control)
-    own = (codes >= 0) & ~control
-    own_rows = np.flatnonzero(own)
-    own_codes = codes[own_rows]
     all_rows = np.flatnonzero(codes >= 0)
     all_codes_device = jnp.asarray(codes[all_rows])
     control_contribution = jnp.take(contribution, jnp.asarray(control_rows), axis=0)
-    control_logits = jnp.asarray(shared[control_rows])
+    if compact_given:
+        control_basis = jnp.take(basis_device, jnp.asarray(control_rows), axis=0)
+        own_basis = jnp.take(basis_device, jnp.asarray(own_rows), axis=0)
+        own_logits = jnp.sum(
+            own_basis * coefficients_device[jnp.asarray(own_codes)], axis=1
+        )
+        control_logits = None
+    else:
+        control_logits = jnp.asarray(shared[control_rows])
+        own_logits = jnp.asarray(shared[own_rows]) + alpha_device[jnp.asarray(own_codes)]
     own_contribution = jnp.take(contribution, jnp.asarray(own_rows), axis=0)
-    own_logits = jnp.asarray(shared[own_rows]) + alpha_device[jnp.asarray(own_codes)]
     own_codes_device = jnp.asarray(own_codes)
 
     observed = jax.ops.segment_sum(
@@ -1574,7 +1619,11 @@ def fit_low_moi_propensity_saddlepoint(
     mean_parts, variance_parts, third_parts = [], [], []
     for start in range(0, num_targets, target_batch_size):
         stop = min(start + target_batch_size, num_targets)
-        selection = jax.nn.sigmoid(control_logits[None, :] + alpha_device[start:stop, None])
+        if compact_given:
+            batch_logits = coefficients_device[start:stop] @ control_basis.T
+        else:
+            batch_logits = control_logits[None, :] + alpha_device[start:stop, None]
+        selection = jax.nn.sigmoid(batch_logits)
         bernoulli = selection * (1.0 - selection)
         third_weight = bernoulli * (1.0 - 2.0 * selection)
         batch_mean = selection @ control_contribution
@@ -1633,7 +1682,12 @@ def fit_low_moi_propensity_saddlepoint(
                 own_index[target, :count] = own_rows[order[starts[target] : starts[target] + count]]
         own_index_device = jnp.asarray(own_index)
         contribution_ext = jnp.concatenate([contribution, jnp.zeros((1, num_genes), dtype=contribution.dtype)], axis=0)
-        shared_ext = jnp.concatenate([jnp.asarray(shared), jnp.zeros((1,), dtype=jnp.float64)])
+        if compact_given:
+            basis_ext = jnp.concatenate(
+                [basis_device, jnp.zeros((1, basis_device.shape[1]), dtype=jnp.float64)], axis=0
+            )
+        else:
+            shared_ext = jnp.concatenate([jnp.asarray(shared), jnp.zeros((1,), dtype=jnp.float64)])
 
         for start in range(0, pair_targets.size, gene_block_size):
             targets = pair_targets[start : start + gene_block_size]
@@ -1643,10 +1697,18 @@ def fit_low_moi_propensity_saddlepoint(
             t_dev = jnp.asarray(np.concatenate([targets, np.repeat(targets[-1], pad)]).astype(np.int32))
             g_dev = jnp.asarray(np.concatenate([genes, np.repeat(genes[-1], pad)]).astype(np.int32))
             block_controls = jnp.take(control_contribution, g_dev, axis=1)
-            logits_controls = control_logits[:, None] + alpha_device[t_dev][None, :]
+            if compact_given:
+                logits_controls = control_basis @ coefficients_device[t_dev].T
+            else:
+                logits_controls = control_logits[:, None] + alpha_device[t_dev][None, :]
             rows = own_index_device[t_dev]                                   # (pairs, width)
             block_own = contribution_ext[rows, g_dev[:, None]].T             # (width, pairs)
-            logits_own = (shared_ext[rows] + alpha_device[t_dev][:, None]).T
+            if compact_given:
+                logits_own = jnp.einsum(
+                    "pwq,pq->wp", basis_ext[rows], coefficients_device[t_dev]
+                )
+            else:
+                logits_own = (shared_ext[rows] + alpha_device[t_dev][:, None]).T
             if projection is not None:
                 block_controls, block_own = projection.correct_blocks(t_dev, g_dev, rows, block_controls, block_own)
             fitted_log_p, fitted_valid = propensity_saddlepoint_log_two_sided(

--- a/src/perturbo/_internal/score_resampling.py
+++ b/src/perturbo/_internal/score_resampling.py
@@ -352,20 +352,30 @@ class TargetPermutations:
     seed: int
     resampling_mechanism: str = "permutation"
     pair_rows: tuple[np.ndarray | None, ...] | None = None
-    """Row indices of each target's pool: its own cells plus every control."""
+    """Row indices of each target's pool when Bernoulli draws were requested.
+
+    Saddlepoint-only runs keep ``None`` entries because the compact coefficient
+    model reconstructs its pools without retaining one control-row vector per
+    target."""
     pool_logits: tuple[np.ndarray | None, ...] | None = None
     """Fitted selection log-odds over those pool rows, under the propensity
     mechanism. Logits rather than probabilities because the saddlepoint's CGF
     is written in the logit, and a float32 probability cannot carry one near
     the clip - sigmoid(30) rounds to exactly 1.0."""
     shared_logits: np.ndarray | None = None
-    """The covariate part of the selection model, one float64 value per cell,
-    shared by every target. ``pool_logits[t]`` is ``shared_logits[pair_rows[t]]
-    + pool_intercepts[t]`` rounded to float32; the decomposition is kept so the
-    saddlepoint can screen every target at once."""
+    """Legacy shared-slope representation retained for old cached callers."""
     pool_intercepts: np.ndarray | None = None
     """Per-target intercept of the selection model, NaN where the target has
     no pool."""
+    propensity_coefficients: np.ndarray | None = None
+    """Target-specific pool fits in ``propensity_basis`` coordinates.
+
+    Shape ``(targets, basis)``. Unlike the legacy shared-slope decomposition,
+    each row is fitted using only controls and that target's own cells, so an
+    unrelated target cannot change this target's assignment law."""
+    propensity_basis: np.ndarray | None = None
+    """Rank-revealing ``(cells, basis)`` design shared by the compact
+    target-specific propensity coefficients."""
 
     def __post_init__(self) -> None:
         if any(entry is not None and entry.ndim != 2 for entry in self.indices):
@@ -399,6 +409,16 @@ def _solve_propensity_intercept(
     return 0.5 * (low + high)
 
 
+def _target_propensity_key(seed: int, target_name: str) -> jax.Array:
+    """A JAX key stable to target ordering and chunk composition."""
+
+    digest = hashlib.blake2b(str(target_name).encode("utf-8"), digest_size=8).digest()
+    value = int.from_bytes(digest, "big")
+    key = jax.random.key(int(seed))
+    key = jax.random.fold_in(key, np.uint32(value & 0xFFFFFFFF))
+    return jax.random.fold_in(key, np.uint32(value >> 32))
+
+
 def precompute_low_moi_permutations(
     design: JointNBDesign | object,
     *,
@@ -407,6 +427,7 @@ def precompute_low_moi_permutations(
     seed: int = 0,
     resampling_mechanism: str = "permutation",
     draw_resamples: bool = True,
+    propensity_target_batch_size: int = 64,
 ) -> TargetPermutations:
     """Draw every target's resamples once, for reuse across gene chunks.
 
@@ -442,29 +463,44 @@ def precompute_low_moi_permutations(
     # Imported here rather than at module scope: high_moi's package __init__
     # pulls in its api, which imports this module back.
     from perturbo._internal.high_moi.resampling import (
-        fit_propensity_coefficients,
+        fit_masked_propensity_coefficients,
+        propensity_basis,
         propensity_logits_from_coefficients,
         sample_propensity_indices,
     )
     nuisance = np.asarray(design.nuisance_design, dtype=np.float32)
-    shared_eta = None
+    propensity_coef = None
+    propensity_Q = None
     if resampling_mechanism == "propensity":
-        # One fit of "carries a targeting guide" against "carries a control",
-        # over every cell, giving the covariate part of the selection model.
-        if target_codes is not None:
-            targeting = (target_codes >= 0).astype(np.float32)
-        else:
-            targeting = (target_design.sum(axis=1) > 0).astype(np.float32)
-        shared_coefficients, shared_basis = fit_propensity_coefficients(
-            targeting.reshape(1, -1), nuisance
+        if propensity_target_batch_size < 1:
+            raise ValueError("propensity_target_batch_size must be positive.")
+        # One model per target, each fitted on exactly the population used by
+        # its CRT: controls plus that target's own cells. This makes the fitted
+        # assignment law independent of unrelated targets in the same CLI
+        # chunk. Coefficients share a compact rank-revealing basis, so the
+        # saddlepoint can still screen targets in batches without retaining an
+        # all-target x all-cell logit matrix.
+        propensity_Q = np.asarray(propensity_basis(nuisance), dtype=np.float32)
+        propensity_coef = np.zeros(
+            (design.num_targets, propensity_Q.shape[1]), dtype=np.float32
         )
-        shared_eta = np.asarray(
-            propensity_logits_from_coefficients(shared_coefficients, shared_basis)
-        ).reshape(-1).astype(np.float64)
+        for start in range(0, design.num_targets, int(propensity_target_batch_size)):
+            stop = min(start + int(propensity_target_batch_size), design.num_targets)
+            targets = np.arange(start, stop, dtype=np.int32)
+            if target_codes is not None:
+                indicators = target_codes[None, :] == targets[:, None]
+            else:
+                indicators = target_design[:, start:stop].T > 0
+            inclusion = control_mask[None, :] | indicators
+            propensity_coef[start:stop] = np.asarray(
+                fit_masked_propensity_coefficients(
+                    indicators,
+                    inclusion,
+                    propensity_Q,
+                )
+            )
     pair_rows: list[np.ndarray | None] = []
     pool_logits: list[np.ndarray | None] = []
-    pool_intercepts = np.full(design.num_targets, np.nan, dtype=np.float64)
-    key = jax.random.key(seed)
     drawn: list[np.ndarray | None] = []
     for target_index in range(design.num_targets):
         if target_design is None:
@@ -497,25 +533,24 @@ def precompute_low_moi_permutations(
         # because a perturbed cell is not a valid "could have been this target"
         # counterfactual - its expression already moved.
         #
-        # Covariate effects are shared across targets and only the intercept is
-        # per target. Depth, guide load and batch act on the *cell*, not on
-        # which guide it happened to receive, so there is no reason for their
-        # coefficients to differ by target - only abundance does, and that is
-        # the intercept. Fitting them jointly turns hundreds of events per
-        # target into every event at once, which removes the separation risk a
-        # per-target fit runs at this imbalance, and removes a QR and a
-        # (pool x q x q) curvature solve per target: with 48 batch levels that
-        # per-target fit was the whole precompute.
-        rows = np.flatnonzero(pair_mask)
-        offsets = shared_eta[rows]
-        intercept = _solve_propensity_intercept(offsets, int(observed_assignment.sum()))
-        logits = (offsets + intercept).astype(np.float32, copy=False)
-        pair_rows.append(rows.astype(np.int64, copy=False))
-        pool_logits.append(logits)
-        pool_intercepts[target_index] = intercept
+        # Coefficients are target-specific because the actual pool is
+        # target-specific. They still share one compact basis, which lets the
+        # saddlepoint batch targets and keeps storage proportional to targets x
+        # covariates rather than targets x controls.
         if not draw_resamples:
+            pair_rows.append(None)
+            pool_logits.append(None)
             drawn.append(None)
             continue
+        rows = np.flatnonzero(pair_mask)
+        logits = np.asarray(
+            propensity_logits_from_coefficients(
+                propensity_coef[target_index : target_index + 1],
+                propensity_Q[rows],
+            )
+        ).reshape(-1).astype(np.float32, copy=False)
+        pair_rows.append(rows.astype(np.int64, copy=False))
+        pool_logits.append(logits)
         # Pad the pool to a common length before drawing. The sampler's index
         # extraction is compiled per (pool, width) shape, and every target's
         # pool - the controls plus its own cells - has its own length, so an
@@ -531,7 +566,7 @@ def precompute_low_moi_permutations(
             sample_propensity_indices(
                 selection,
                 num_resamples=num_resamples,
-                key=jax.random.fold_in(key, target_index),
+                key=_target_propensity_key(seed, target_names[target_index]),
                 pad_value=int(rows.size),
             ).astype(np.int32, copy=False)
         )
@@ -542,8 +577,10 @@ def precompute_low_moi_permutations(
         resampling_mechanism=resampling_mechanism,
         pair_rows=tuple(pair_rows) if resampling_mechanism == "propensity" else None,
         pool_logits=tuple(pool_logits) if resampling_mechanism == "propensity" else None,
-        shared_logits=shared_eta if resampling_mechanism == "propensity" else None,
-        pool_intercepts=pool_intercepts if resampling_mechanism == "propensity" else None,
+        shared_logits=None,
+        pool_intercepts=None,
+        propensity_coefficients=propensity_coef if resampling_mechanism == "propensity" else None,
+        propensity_basis=propensity_Q if resampling_mechanism == "propensity" else None,
     )
 
 
@@ -901,35 +938,52 @@ def newton_step_magnitude(
     construction and the solve never sees an indefinite matrix.
     """
 
-    theta_row = theta[None, :]
-    eta = offsets + nuisance_design @ beta
-    mean = np.exp(np.clip(eta, -_ETA_CLIP, _ETA_CLIP))
-    denominator = theta_row + mean
-    residual = theta_row * (counts - mean) / denominator
-    weight = theta_row * mean / denominator
-    gradient = nuisance_design.T @ residual - prior_precision * beta
+    design = np.asarray(nuisance_design, dtype=np.float64)
+    coefficients = np.asarray(beta, dtype=np.float64)
+    count_panel = np.asarray(counts)
+    offset_panel = np.asarray(offsets, dtype=np.float64)
+    if offset_panel.ndim == 1:
+        offset_panel = offset_panel[:, None]
+    dispersion = np.asarray(theta, dtype=np.float64).reshape(-1)
 
-    # Gene-blocked, and a matmul rather than an einsum. Both matter once the
-    # nuisance design is wide: the work is cells x genes x nuisance^2, which at
+    # Gene-block every cells-by-genes intermediate as well as the curvature.
+    # This matters before the solve even starts: eta, mean, denominator,
+    # residual and weight are five full float64 copies of the count panel if
+    # they are formed above this loop.
+    #
+    # A matmul rather than an einsum matters once the nuisance design is wide:
+    # the work is cells x genes x nuisance^2, which at
     # 10k control cells, 8k genes and 267 gem-group columns is 5.9e12
     # multiply-adds. np.einsum is not BLAS-backed and runs that single-threaded
     # - measured 1.8 hours against 2.9 minutes for the same arithmetic
     # expressed as Z' (Z * w) - and it materializes the whole
     # (genes, nuisance, nuisance) tensor, 4.4 GiB here, when only one block is
     # ever live.
-    num_genes = int(weight.shape[1])
-    num_nuisance = int(nuisance_design.shape[1])
+    num_genes = int(coefficients.shape[1])
+    num_nuisance = int(design.shape[1])
     block = max(1, min(num_genes, _NEWTON_STEP_GENE_BLOCK))
     magnitude = np.empty(num_genes, dtype=np.float64)
     curvature = np.empty((block, num_nuisance, num_nuisance), dtype=np.float64)
     for start in range(0, num_genes, block):
         stop = min(start + block, num_genes)
         width = stop - start
+        block_counts = np.asarray(count_panel[:, start:stop], dtype=np.float64)
+        block_beta = coefficients[:, start:stop]
+        block_theta = dispersion[None, start:stop]
+        block_offsets = (
+            offset_panel if offset_panel.shape[1] == 1 else offset_panel[:, start:stop]
+        )
+        eta = block_offsets + design @ block_beta
+        mean = np.exp(np.clip(eta, -_ETA_CLIP, _ETA_CLIP))
+        denominator = block_theta + mean
+        residual = block_theta * (block_counts - mean) / denominator
+        weight = block_theta * mean / denominator
+        gradient = design.T @ residual - prior_precision * block_beta
         for offset in range(width):
-            column = weight[:, start + offset, None]
-            curvature[offset] = nuisance_design.T @ (nuisance_design * column)
+            column = weight[:, offset, None]
+            curvature[offset] = design.T @ (design * column)
         block_curvature = curvature[:width] + ridge
-        step = np.linalg.solve(block_curvature, gradient.T[start:stop, :, None])[:, :, 0].T
+        step = np.linalg.solve(block_curvature, gradient.T[:, :, None])[:, :, 0].T
         magnitude[start:stop] = np.max(np.abs(step), axis=0)
     return magnitude
 
@@ -2094,9 +2148,17 @@ def run_low_moi_score_permutations(
                         "resampling_mechanism='propensity', which keeps each target's pool "
                         "rows and logits."
                     )
-                if permutations.shared_logits is None or permutations.pool_intercepts is None:
+                compact_propensity = (
+                    permutations.propensity_coefficients is not None
+                    and permutations.propensity_basis is not None
+                )
+                legacy_propensity = (
+                    permutations.shared_logits is not None
+                    and permutations.pool_intercepts is not None
+                )
+                if not compact_propensity and not legacy_propensity:
                     raise ValueError(
-                        "permutations predate the decomposed selection model; recompute them "
+                        "permutations do not carry a compact selection model; recompute them "
                         "with precompute_low_moi_permutations."
                     )
                 # The pool projection: the contributions are efficient under the
@@ -2109,8 +2171,12 @@ def run_low_moi_score_permutations(
                     contribution=_low_moi_contribution(),
                     target_codes=target_codes,
                     control_mask=control_mask,
-                    shared_logits=permutations.shared_logits,
-                    intercepts=permutations.pool_intercepts,
+                    shared_logits=(permutations.shared_logits if legacy_propensity else None),
+                    intercepts=(permutations.pool_intercepts if legacy_propensity else None),
+                    propensity_coefficients=(
+                        permutations.propensity_coefficients if compact_propensity else None
+                    ),
+                    propensity_basis=(permutations.propensity_basis if compact_propensity else None),
                     num_targets=design.num_targets,
                     screen_p_value=saddlepoint_screen_p_value,
                     two_sided=saddlepoint_two_sided or "equal-tail",

--- a/src/perturbo/cli.py
+++ b/src/perturbo/cli.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import asdict
+from dataclasses import asdict, replace
 import json
 import warnings
 from pathlib import Path
@@ -43,6 +43,7 @@ from .core import (
     _resolve_perturbation_modality,
     _save_loss_plot,
     _save_multi_loss_plot,
+    _sum_matrix_rows_bounded,
     _ReusableSVIRunner,
     _validate_cli_input_keys,
     _validate_clip_percentile,
@@ -52,6 +53,7 @@ from .core import (
     fit_perturbation_effects,
     load_analysis_cells,
     load_controls,
+    subset_control_fit_genes,
 )
 from .io import MuDataSetup, control_fit_arrays, save_array_bundle, save_light_fit_bundle
 from .crt import (
@@ -59,9 +61,9 @@ from .crt import (
     CRT_ALL_TAIL_FAMILIES,
     CRT_MECHANISMS,
     CRT_SADDLEPOINT_FAMILY,
-    CRT_TAIL_FAMILIES,
     DEFAULT_NEWTON_STEP_TOLERANCE,
     exclude_targets,
+    prepare_all_cells_propensity,
     prepare_crt_baseline,
     run_crt_all_cells,
     run_crt_for_chunk,
@@ -117,6 +119,148 @@ def _guide_efficacy_for_cli(
     if arr.ndim == 1:
         return np.clip(arr, a_min=0.0, a_max=None)
     return np.clip(arr.reshape(int(n_guides), -1).mean(axis=1), a_min=0.0, a_max=None).astype(np.float32)
+
+
+_GUIDE_POSTERIOR_FIELDS = (
+    "guide_effect_mean",
+    "guide_effect_scale",
+    "guide_effect_z_values",
+    "guide_relative_efficiency_mean",
+    "guide_relative_efficiency_scale",
+    "guide_offset_mean",
+    "guide_offset_scale",
+    "guide_dispersion_excess_inverse",
+)
+
+
+def _merge_chunk_guide_posteriors(
+    buffers: dict[str, np.ndarray],
+    seen: dict[str, np.ndarray],
+    chunk_fit: BetaFit,
+    *,
+    chunk_guide_names: list[str],
+    global_guide_names: list[str],
+) -> None:
+    """Merge guide-indexed chunk results by guide name, never by local row."""
+    if len(set(global_guide_names)) != len(global_guide_names):
+        raise ValueError("Guide names must be unique to combine chunked posterior arrays.")
+    global_index = {name: index for index, name in enumerate(global_guide_names)}
+    try:
+        target_rows = np.asarray([global_index[name] for name in chunk_guide_names], dtype=np.int64)
+    except KeyError as error:
+        raise ValueError(f"Chunk returned an unknown guide name: {error.args[0]!r}.") from error
+
+    for field in _GUIDE_POSTERIOR_FIELDS:
+        value = getattr(chunk_fit, field)
+        if value is None:
+            continue
+        array = np.asarray(value)
+        if array.shape[0] != len(chunk_guide_names):
+            raise ValueError(
+                f"Chunk guide posterior {field!r} has {array.shape[0]} rows for "
+                f"{len(chunk_guide_names)} guide names."
+            )
+        if field not in buffers:
+            buffers[field] = np.full(
+                (len(global_guide_names), *array.shape[1:]),
+                np.nan,
+                dtype=array.dtype,
+            )
+            seen[field] = np.zeros(len(global_guide_names), dtype=bool)
+        elif buffers[field].shape[1:] != array.shape[1:]:
+            raise ValueError(
+                f"Chunk guide posterior {field!r} changed trailing shape from "
+                f"{buffers[field].shape[1:]} to {array.shape[1:]}."
+            )
+        buffers[field][target_rows] = array
+        seen[field][target_rows] = True
+
+
+def _finalize_chunk_guide_posteriors(
+    buffers: dict[str, np.ndarray],
+    seen: dict[str, np.ndarray],
+    *,
+    global_guide_names: list[str],
+) -> dict[str, jnp.ndarray]:
+    for field, mask in seen.items():
+        if not np.all(mask):
+            missing = [name for name, present in zip(global_guide_names, mask, strict=True) if not present]
+            raise ValueError(
+                f"Chunked fitting did not return {field!r} for {len(missing)} guide(s): "
+                + ", ".join(missing[:5])
+                + ("..." if len(missing) > 5 else "")
+            )
+    return {field: jnp.asarray(array) for field, array in buffers.items()}
+
+
+def _bundle_size_factors(
+    adata: Any,
+    *,
+    selected_row_indices: np.ndarray | None = None,
+    size_factor_mode: str,
+    size_factor_key: str | None,
+    library_size_key: str | None,
+    library_size_center_log_mean: float | None,
+    gene_clip_thresholds: np.ndarray | None,
+    winsorize_gene_expression: bool,
+) -> tuple[np.ndarray | None, str]:
+    """Materialize the exact per-cell offset needed by a simulation bundle."""
+    source_n_obs = int(adata.n_obs)
+    if selected_row_indices is None:
+        selected_rows = np.arange(source_n_obs, dtype=np.int64)
+    else:
+        selected_rows = np.asarray(selected_row_indices, dtype=np.int64)
+        if selected_rows.ndim != 1:
+            raise ValueError("selected_row_indices must be one-dimensional.")
+        if selected_rows.size and (
+            np.any(selected_rows < 0) or np.any(selected_rows >= source_n_obs)
+        ):
+            raise IndexError("selected_row_indices contains a row outside the source data.")
+    n_obs = int(selected_rows.size)
+    selected_obs = adata.obs.iloc[selected_rows]
+    if size_factor_mode == "infer":
+        return None, "latent"
+    if size_factor_mode == "none":
+        return np.zeros((n_obs, 1), dtype=np.float32), "fixed_zero"
+    if size_factor_key is not None:
+        values = pd.to_numeric(selected_obs[size_factor_key], errors="coerce").to_numpy(dtype=np.float32)
+        return values.reshape(-1, 1), "obs_size_factor"
+    if library_size_key is not None:
+        library_size = pd.to_numeric(selected_obs[library_size_key], errors="coerce").to_numpy(dtype=np.float64)
+        center = float(library_size_center_log_mean or 0.0)
+        return (np.log1p(library_size) - center).astype(np.float32)[:, None], "obs_library_size"
+
+    totals = np.empty(n_obs, dtype=np.float64)
+    row_chunk_size = min(BACKED_ROW_CHUNK_SIZE, max(n_obs, 1))
+    for start in range(0, n_obs, row_chunk_size):
+        stop = min(start + row_chunk_size, n_obs)
+        block = adata.X[selected_rows[start:stop], :]
+        if winsorize_gene_expression and gene_clip_thresholds is not None:
+            if hasattr(block, "toarray"):
+                block = block.toarray()
+            block = np.asarray(block)
+            block = np.minimum(block, np.asarray(gene_clip_thresholds)[None, :])
+            block_totals = block.sum(axis=1, dtype=np.float64)
+        else:
+            block_totals = block.sum(axis=1, dtype=np.float64)
+        totals[start:stop] = np.asarray(block_totals, dtype=np.float64).reshape(-1)
+    center = float(library_size_center_log_mean or 0.0)
+    return (np.log1p(totals) - center).astype(np.float32)[:, None], "analyzed_count_total"
+
+
+def _gene_chunk_configuration_problem(args, size_factor_mode: str) -> str | None:
+    """Gene blocks are independent only under the supported fixed-offset model."""
+    if args.likelihood != "negbin":
+        return "gene chunking currently requires --likelihood negbin"
+    if size_factor_mode not in {"observed", "none"}:
+        return "gene chunking requires observed or fixed-zero size factors"
+    if args.num_factors or args.guide_random_effects or args.propagate_baseline_uncertainty:
+        return "gene chunking requires zero latent factors and no guide random effects or baseline uncertainty propagation"
+    if args.guide_effect_strategy != "shared" or args.guide_activity_mode != "always_on":
+        return "gene chunking currently requires shared, always-on guide effects"
+    if args.fit_perturbation_dispersion:
+        return "gene chunking currently requires fixed perturbation dispersion"
+    return None
 
 
 def _crt_configuration_problem(args, size_factor_mode) -> str | None:
@@ -547,9 +691,9 @@ def main(argv: list[str] | None = None) -> None:
         type=float,
         default=0.01,
         help=(
-            "Adam learning rate for both SVI stages. Adam moves a coefficient by about this much per step, so the "
-            "rate times the step count must exceed the largest effect in nats: 0.01 with 500 beta steps recovers "
-            "simulated effects as well as 0.003 with 2,500, and 0.003 with 300 under-converges."
+            "Adam learning rate for both SVI stages. Convergence depends on the data, effect sizes, and "
+            "minibatch size. Compare longer fits before interpreting effect magnitudes; the default "
+            "500 steps can underestimate strong knockdowns."
         ),
     )
     parser.add_argument(
@@ -580,12 +724,25 @@ def main(argv: list[str] | None = None) -> None:
         help="If >0, subsample cells per step for beta minibatch SVI",
     )
     parser.add_argument(
+        "--gene-chunk-size",
+        type=int,
+        default=0,
+        help=(
+            "Genes loaded and fit together in stage two; keeps every cell and perturbation predictor. "
+            "0 uses perturbation chunks for mutually exclusive assignments and 256-gene blocks "
+            "when co-occurring perturbations would otherwise be split. Requires plain NB with fixed "
+            "size factors, shared guide effects, and no latent factors or extra dispersion. "
+            "Control fitting remains capped by --max-control-cells."
+        ),
+    )
+    parser.add_argument(
         "--perturbation-chunk-size",
         type=int,
         default=0,
         help=(
             "Maximum perturbations per chunk when fitting betas. "
-            "If 0, chunk size is chosen automatically from --max-chunk-size."
+            "If 0, chunk size is chosen automatically from --max-chunk-size. "
+            "Co-occurring assignments use gene blocks to retain the joint model."
         ),
     )
     parser.add_argument(
@@ -841,12 +998,15 @@ def main(argv: list[str] | None = None) -> None:
 
     chunks: list[_PerturbationChunk] | None = None
     all_perturbation_names = None
+    all_guide_names: list[str] | None = None
     analysis_gene_names = None
     threshold_floor = _validate_gene_outlier_threshold_floor(args.gene_outlier_threshold_floor)
     apply_filter_cells = args.gene_outlier_action == "filter_cells"
     apply_winsorize = args.winsorize_gene_expression_outliers
     if args.perturbation_chunk_size < 0:
         raise ValueError("--perturbation-chunk-size must be >= 0.")
+    if args.gene_chunk_size < 0:
+        raise ValueError("--gene-chunk-size must be >= 0.")
     if args.max_chunk_size < 1:
         raise ValueError("--max-chunk-size must be >= 1.")
     if args.outlier_cell_min_genes < 0:
@@ -916,11 +1076,19 @@ def main(argv: list[str] | None = None) -> None:
             f"--max-chunk-size={args.max_chunk_size}."
         )
 
+    gene_chunk_size = args.gene_chunk_size or None
+    if gene_chunk_size is not None:
+        problem = _gene_chunk_configuration_problem(args, size_factor_mode)
+        if problem is not None:
+            raise ValueError(problem)
+        should_chunk = False
+
     if should_chunk:
         analysis_gene_names = _extract_gene_names(analysis_adata_for_workflow, args.gene_name_key)
         if args.perturbation_modality_key is not None:
             pert_adata = _resolve_perturbation_modality(data, args.perturbation_modality_key)
             pert_adata = pert_adata[analysis_adata_for_workflow.obs_names]
+            all_guide_names = _extract_pert_names(pert_adata)
             pert_matrix = _get_layer_matrix(pert_adata, args.perturbation_layer)
             if args.perturbation_element_varm_key is not None:
                 element_mapping, element_names = _load_perturbation_element_mapping(
@@ -928,24 +1096,44 @@ def main(argv: list[str] | None = None) -> None:
                     perturbation_modality_key=args.perturbation_modality_key,
                     perturbation_element_varm_key=args.perturbation_element_varm_key,
                     perturbation_element_names_uns_key=args.perturbation_element_names_uns_key,
+                    preserve_sparse=True,
                 )
-                pert_matrix = _group_perturbation_matrix_by_element(pert_matrix, element_mapping)
+                pert_matrix = _group_perturbation_matrix_by_element(pert_matrix, element_mapping, preserve_sparse=True)
                 all_perturbation_names = element_names
             else:
                 all_perturbation_names = _extract_pert_names(pert_adata)
-            membership = _build_matrix_membership(
-                pert_matrix,
-                num_perts=len(all_perturbation_names),
-            )
-            chunks = _construct_perturbation_chunks(
-                all_perturbation_names,
-                membership,
-                max_chunk_size=args.max_chunk_size,
-                max_perturbations_per_chunk=args.perturbation_chunk_size or None,
-            )
+            # Dropping a co-occurring predictor changes the fitted model. For
+            # overlapping assignments block genes instead, keeping all columns.
+            active_per_cell = np.asarray((pert_matrix > 0).sum(axis=1)).reshape(-1)
+            if np.any(active_per_cell > 1):
+                problem = _gene_chunk_configuration_problem(args, size_factor_mode)
+                if problem is not None:
+                    raise ValueError(
+                        "Perturbation chunks would omit co-occurring predictors, and " + problem
+                        + ". Use a supported gene-block configuration, or raise --max-chunk-size "
+                        "to fit all cells jointly with --perturbation-chunk-size 0."
+                    )
+                gene_chunk_size = 256
+                print("[perturbo] Co-occurring perturbations detected: using 256-gene blocks with every predictor retained.")
+            else:
+                membership = _build_matrix_membership(
+                    pert_matrix,
+                    num_perts=len(all_perturbation_names),
+                )
+                chunks = _construct_perturbation_chunks(
+                    all_perturbation_names,
+                    membership,
+                    max_chunk_size=args.max_chunk_size,
+                    max_perturbations_per_chunk=args.perturbation_chunk_size or None,
+                )
+                del membership
+            del pert_matrix, pert_adata
+            if args.perturbation_element_varm_key is not None:
+                del element_mapping
         else:
             pert_series = analysis_adata_for_workflow.obs[args.perturbation_key].astype(str)
             all_perturbation_names = [str(x) for x in pd.Categorical(pert_series).categories.tolist()]
+            all_guide_names = list(all_perturbation_names)
             membership = _build_obs_membership(pert_series, all_perturbation_names)
             chunks = _construct_perturbation_chunks(
                 all_perturbation_names,
@@ -991,6 +1179,9 @@ def main(argv: list[str] | None = None) -> None:
     svi_cfg = SVIConfig(step_size=args.step_size, num_particles=args.num_particles)
     minibatch_control = args.minibatch_size_control or args.minibatch_size or None
     minibatch_betas = args.minibatch_size_betas or args.minibatch_size or None
+    if gene_chunk_size is not None and minibatch_betas is None:
+        minibatch_betas = min(1024, int(n_analysis_cells))
+        print(f"[perturbo] Gene blocks use {minibatch_betas} cells per SVI step; override with --minibatch-size-betas.")
     schedule = resolve_training_schedule(
         shared_steps=args.num_steps,
         shared_epochs=args.num_epochs,
@@ -1001,6 +1192,15 @@ def main(argv: list[str] | None = None) -> None:
         default_control_steps=500,
         default_beta_steps=500,
     )
+    if gene_chunk_size is not None and not args.crt_only:
+        planned_steps = schedule.resolve_stage_steps(
+            stage="beta", num_cells=int(n_analysis_cells), minibatch_size=minibatch_betas,
+        )
+        expected_passes = planned_steps * min(int(minibatch_betas), int(n_analysis_cells)) / int(n_analysis_cells)
+        print(
+            f"[perturbo] Each gene block: {planned_steps} SVI steps, {expected_passes:.2f} expected cell passes. "
+            "Set --num-epochs-betas to specify training coverage."
+        )
 
     if args.num_factors < 0:
         raise ValueError("--num-factors must be >= 0.")
@@ -1036,7 +1236,7 @@ def main(argv: list[str] | None = None) -> None:
 
     crt_baseline = None
     crt_accumulator: CRTAccumulator | None = None
-    if args.crt and crt_pool == "control-anchored":
+    if args.crt and crt_pool == "control-anchored" and gene_chunk_size is None:
         print("[perturbo] Preparing CRT baseline from the stage-1 fit...")
         crt_baseline = prepare_crt_baseline(
             controls,
@@ -1048,7 +1248,13 @@ def main(argv: list[str] | None = None) -> None:
         if crt_baseline.pre_polish_check is not None:
             print(f"[perturbo] CRT baseline before polishing: {crt_baseline.pre_polish_check.describe()}")
         print(f"[perturbo] CRT baseline: {crt_baseline.null_check.describe()}")
-    def _run_crt_on_chunk(chunk_source: PerTurboData, accumulator: CRTAccumulator) -> None:
+    def _run_crt_on_chunk(
+        chunk_source: PerTurboData,
+        accumulator: CRTAccumulator,
+        *,
+        baseline_source=None,
+        control_source=None,
+    ) -> None:
         """Test one chunk's perturbations, skipping the control elements.
 
         Control cells are already the pool, so testing them as targets from the
@@ -1084,9 +1290,9 @@ def main(argv: list[str] | None = None) -> None:
                 print(f"[perturbo] CRT: skipping {len(control_names)} control element(s) as targets.")
         accumulator.absorb(
             run_crt_for_chunk(
-                crt_baseline,
+                crt_baseline if baseline_source is None else baseline_source,
                 testable,
-                control_data=controls,
+                control_data=controls if control_source is None else control_source,
                 num_resamples=args.crt_num_resamples,
                 seed=args.crt_seed,
                 gene_chunk_size=args.crt_gene_chunk_size,
@@ -1110,23 +1316,34 @@ def main(argv: list[str] | None = None) -> None:
             svi_result=None,
         )
 
-    def _run_all_cells_crt(full_data: PerTurboData) -> CRTAccumulator:
+    all_cells_propensity = None
+
+    def _run_all_cells_crt(
+        full_data: PerTurboData,
+        *,
+        block_control_fit=None,
+        accumulator=None,
+    ) -> CRTAccumulator:
         """The high-MOI CRT over every analysed cell at once, independent of stage-two chunking."""
+        nonlocal all_cells_propensity
         started = time.perf_counter()
         print("[perturbo] Preparing the all-cells CRT baseline: stage-1 fit polished over every analysed cell...")
         baseline = prepare_crt_baseline(
             full_data,
-            control_fit,
+            control_fit if block_control_fit is None else block_control_fit,
             step_tolerance=args.crt_baseline_step_tolerance,
             strict=not args.crt_allow_unconverged_baseline,
             polish=True,
         )
         print(f"[perturbo] CRT baseline: {baseline.null_check.describe()}")
-        accumulator = CRTAccumulator(
-            element_names=tuple(str(name) for name in full_data.pert_names),
-            gene_names=tuple(str(name) for name in full_data.gene_names),
-            tail_families=tuple(args.crt_tail_families),
-        )
+        if gene_chunk_size is not None and all_cells_propensity is None:
+            all_cells_propensity = prepare_all_cells_propensity(baseline, full_data)
+        if accumulator is None:
+            accumulator = CRTAccumulator(
+                element_names=tuple(str(name) for name in full_data.pert_names),
+                gene_names=tuple(str(name) for name in full_data.gene_names),
+                tail_families=tuple(args.crt_tail_families),
+            )
         accumulator.absorb(
             run_crt_all_cells(
                 baseline,
@@ -1134,12 +1351,13 @@ def main(argv: list[str] | None = None) -> None:
                 gene_chunk_size=args.crt_gene_chunk_size,
                 screen_p_value=args.crt_screen_p_value,
                 two_sided=args.crt_two_sided,
+                **({"propensity_fit": all_cells_propensity} if all_cells_propensity is not None else {}),
             )
         )
         print(f"[perturbo] CRT (all-cells pool) complete in {time.perf_counter() - started:.0f}s")
         return accumulator
 
-    def _load_all_analysis_cells() -> PerTurboData:
+    def _load_all_analysis_cells(*, selected_gene_indices=None, full_panel_library_sizes=None) -> PerTurboData:
         return load_analysis_cells(
             data,
             perturbation_key=args.perturbation_key,
@@ -1160,14 +1378,126 @@ def main(argv: list[str] | None = None) -> None:
             continuous_covariates=continuous_covariates,
             batch_covariate=batch_covariate,
             covariate_transform_state=covariate_transform_state,
-            retain_guide_structure=retain_guide_structure,
+            retain_guide_structure=retain_guide_structure and (
+                gene_chunk_size is None
+                or (args.crt and crt_pool == "all-cells" and all_cells_propensity is None)
+            ),
             library_size_center_log_mean=controls.library_size_center_log_mean,
+            selected_gene_indices=selected_gene_indices,
+            full_panel_library_sizes=full_panel_library_sizes,
+            indexed_perturbation_design=gene_chunk_size is not None,
         )
 
     chunk_losses: list[jnp.ndarray] = []
     guide_efficiency_frames: list[pd.DataFrame] = []
+    chunk_guide_posteriors: dict[str, np.ndarray] = {}
+    chunk_guide_posterior_seen: dict[str, np.ndarray] = {}
     analysis_data: PerTurboData | None = None
     stage_two_skipped = False
+    if gene_chunk_size is not None:
+        analysis_gene_names = _extract_gene_names(analysis_adata, args.gene_name_key)
+        n_genes = len(analysis_gene_names)
+        full_panel_library_sizes = np.zeros(int(n_analysis_cells)) if size_factor_mode == "none" else None
+        if size_factor_mode == "observed" and size_factor_key_for_loading is None and library_size_key_for_loading is None:
+            selected_rows = (
+                np.arange(analysis_adata.n_obs) if cell_keep_mask is None else np.flatnonzero(cell_keep_mask)
+            )
+            print("[perturbo] Computing full-panel library sizes once before reading gene blocks...")
+            if not apply_winsorize or gene_clip_thresholds is None:
+                full_panel_library_sizes = _sum_matrix_rows_bounded(analysis_adata.X, selected_rows)
+            else:
+                full_panel_library_sizes = np.empty(selected_rows.size, dtype=np.float64)
+                for start in range(0, selected_rows.size, BACKED_ROW_CHUNK_SIZE):
+                    stop = min(start + BACKED_ROW_CHUNK_SIZE, selected_rows.size)
+                    block = analysis_adata.X[selected_rows[start:stop], :]
+                    if hasattr(block, "toarray"):
+                        block = block.toarray()
+                    full_panel_library_sizes[start:stop] = np.minimum(
+                        np.asarray(block), gene_clip_thresholds[None, :]
+                    ).sum(axis=1, dtype=np.float64)
+        gene_posteriors: dict[str, np.ndarray] = {}
+        for start in range(0, n_genes, gene_chunk_size):
+            stop = min(start + gene_chunk_size, n_genes)
+            gene_slice = slice(start, stop)
+            print(f"[perturbo] Gene block {start + 1}–{stop}/{n_genes}: every cell and perturbation predictor retained")
+            analysis_data = _load_all_analysis_cells(
+                selected_gene_indices=gene_slice,
+                full_panel_library_sizes=full_panel_library_sizes,
+            )
+            if size_factor_mode == "none":
+                analysis_data.size_factors = _fixed_zero_size_factors(analysis_data.counts)
+            all_perturbation_names = list(analysis_data.pert_names)
+            block_control_fit = subset_control_fit_genes(control_fit, gene_slice)
+            if args.crt:
+                if crt_accumulator is None:
+                    crt_accumulator = CRTAccumulator(
+                        element_names=tuple(all_perturbation_names),
+                        gene_names=tuple(analysis_gene_names),
+                        tail_families=tuple(args.crt_tail_families),
+                    )
+                if crt_pool == "all-cells":
+                    _run_all_cells_crt(
+                        analysis_data, block_control_fit=block_control_fit, accumulator=crt_accumulator
+                    )
+                else:
+                    block_controls = replace(
+                        controls,
+                        counts=controls.counts[:, gene_slice],
+                        gene_names=analysis_gene_names[gene_slice],
+                    )
+                    block_baseline = prepare_crt_baseline(
+                        block_controls,
+                        block_control_fit,
+                        step_tolerance=args.crt_baseline_step_tolerance,
+                        strict=not args.crt_allow_unconverged_baseline,
+                        polish=args.crt_polish_baseline,
+                    )
+                    _run_crt_on_chunk(
+                        analysis_data, crt_accumulator,
+                        baseline_source=block_baseline, control_source=block_controls,
+                    )
+            if analysis_data.guide_matrix is not None:
+                analysis_data = replace(analysis_data, guide_matrix=None, guide_to_element=None)
+            if args.crt_only:
+                block_fit = _nan_beta_fit(len(all_perturbation_names), stop - start)
+            else:
+                block_fit = fit_perturbation_effects(
+                    analysis_data,
+                    block_control_fit,
+                    num_steps=schedule.resolve_stage_steps(
+                        stage="beta", num_cells=int(analysis_data.counts.shape[0]), minibatch_size=minibatch_betas,
+                    ),
+                    prior=args.prior,
+                    svi_config=svi_cfg,
+                    model_name=args.likelihood,
+                    use_observed_size_factors=True,
+                    minibatch_size=minibatch_betas,
+                    progress=args.progress,
+                    progress_chunk_size=args.progress_chunk_size,
+                )
+            for field in ("posterior_mean", "posterior_scale", "z_values", *_GUIDE_POSTERIOR_FIELDS):
+                value = getattr(block_fit, field)
+                if value is None:
+                    continue
+                values = np.asarray(value)
+                if values.ndim != 2 or values.shape[1] != stop - start:
+                    raise ValueError(f"Gene-block posterior {field!r} must have its gene axis last.")
+                if field not in gene_posteriors:
+                    gene_posteriors[field] = np.empty((values.shape[0], n_genes), dtype=values.dtype)
+                gene_posteriors[field][:, gene_slice] = values
+            if block_fit.losses.size:
+                chunk_losses.append(block_fit.losses)
+            # A combined posterior has no single SVI state. Retaining a block's
+            # optimizer state would also keep its device buffers resident.
+            del block_fit, block_control_fit
+        beta_fit = BetaFit(
+            **gene_posteriors,
+            losses=jnp.concatenate(chunk_losses) if chunk_losses else jnp.array([]),
+            svi_result=None,
+        )
+        stage_two_skipped = True
+        if args.crt_only:
+            print("[perturbo] --crt-only: stage two skipped; effect estimates are missing in the element table.")
     if chunks is not None and args.crt and crt_pool == "all-cells":
         # The all-cells pool needs every cell at once, whatever the stage-two
         # chunking does: load the full analysis data, test, and release it.
@@ -1341,6 +1671,16 @@ def main(argv: list[str] | None = None) -> None:
             last_state = chunk_fit.svi_result
             if chunk_fit.losses.size > 0:
                 chunk_losses.append(chunk_fit.losses)
+            if retain_guide_structure:
+                if all_guide_names is None:
+                    raise RuntimeError("Global guide names were not initialized for chunked fitting.")
+                _merge_chunk_guide_posteriors(
+                    chunk_guide_posteriors,
+                    chunk_guide_posterior_seen,
+                    chunk_fit,
+                    chunk_guide_names=list(chunk_data.guide_names or []),
+                    global_guide_names=all_guide_names,
+                )
             if guide_effect_strategy == "relative" and chunk_fit.guide_relative_efficiency_mean is not None:
                 mapping = np.asarray(chunk_data.guide_to_element, dtype=np.float32)
                 guide_names = list(chunk_data.guide_names or [])
@@ -1363,6 +1703,11 @@ def main(argv: list[str] | None = None) -> None:
                     )
                 )
 
+        combined_guide_posteriors = _finalize_chunk_guide_posteriors(
+            chunk_guide_posteriors,
+            chunk_guide_posterior_seen,
+            global_guide_names=list(all_guide_names or []),
+        )
         beta_fit = BetaFit(
             posterior_mean=jnp.asarray(posterior_mean),
             posterior_scale=jnp.asarray(posterior_scale),
@@ -1372,6 +1717,7 @@ def main(argv: list[str] | None = None) -> None:
             dispersion_excess_inverse=(
                 None if dispersion_excess_inverse is None else jnp.asarray(dispersion_excess_inverse)
             ),
+            **combined_guide_posteriors,
         )
         # full = PerTurboData(
         #     counts=jnp.empty((0, len(analysis_gene_names))),
@@ -1588,7 +1934,7 @@ def main(argv: list[str] | None = None) -> None:
         covariate_metadata_path.write_text(json.dumps(metadata, indent=2))
         print(f"[perturbo] Wrote {covariate_metadata_path}")
 
-    if chunks is not None and chunk_losses:
+    if (chunks is not None or gene_chunk_size is not None) and chunk_losses:
         _save_multi_loss_plot(
             chunk_losses,
             out_dir / "beta_loss_curve.png",
@@ -1635,12 +1981,23 @@ def main(argv: list[str] | None = None) -> None:
             guide_element_uns_key=args.perturbation_element_names_uns_key,
             gene_name_key=args.gene_name_key,
             control_substring=args.control_substring,
+            size_factor_mode=size_factor_mode,
         )
         guide_posteriors = {k: v for k, v in _guide_posterior_arrays(beta_fit).items() if v is not None}
         guide_efficacy = _guide_efficacy_for_cli(
             beta_fit,
             guide_effect_strategy=guide_effect_strategy,
             n_guides=len(guide_names),
+        )
+        saved_size_factors, size_factor_provenance = _bundle_size_factors(
+            analysis_adata,
+            selected_row_indices=np.flatnonzero(cell_keep_mask) if cell_keep_mask is not None else None,
+            size_factor_mode=size_factor_mode,
+            size_factor_key=size_factor_key_for_loading,
+            library_size_key=library_size_key_for_loading,
+            library_size_center_log_mean=controls.library_size_center_log_mean,
+            gene_clip_thresholds=gene_clip_thresholds,
+            winsorize_gene_expression=apply_winsorize,
         )
         metadata = {
             "likelihood": args.likelihood,
@@ -1658,6 +2015,8 @@ def main(argv: list[str] | None = None) -> None:
             "perturbation_dispersion_prior_rate": float(args.perturbation_dispersion_prior_rate),
             "fit_guide_efficacy": None,
             "library_size_center_log_mean": controls.library_size_center_log_mean,
+            "size_factor_mode": size_factor_mode,
+            "size_factor_provenance": size_factor_provenance,
             "setup": setup.to_json_dict(),
             "svi_config": asdict(svi_cfg),
             "covariate_transform_state": (
@@ -1692,6 +2051,7 @@ def main(argv: list[str] | None = None) -> None:
                 "max_control_cells": args.max_control_cells,
                 "max_chunk_size": args.max_chunk_size,
                 "perturbation_chunk_size": args.perturbation_chunk_size,
+                "gene_chunk_size": gene_chunk_size,
             },
         }
         save_light_fit_bundle(
@@ -1701,6 +2061,7 @@ def main(argv: list[str] | None = None) -> None:
             beta_arrays=_beta_fit_arrays(beta_fit),
             guide_posteriors=guide_posteriors or None,
             guide_efficacy=guide_efficacy,
+            size_factors=saved_size_factors,
             cell_keep_indices=np.flatnonzero(cell_keep_mask) if cell_keep_mask is not None else None,
         )
         print(f"[perturbo] Wrote simulation-ready model parameter bundle to {out_dir}")

--- a/src/perturbo/core.py
+++ b/src/perturbo/core.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, replace
 from functools import partial
 import json
 from pathlib import Path
@@ -55,6 +55,11 @@ from perturbo.preprocessing.counts import (
 )
 from perturbo.training_schedule import resolve_training_schedule
 from perturbo.utils import compute_size_factors
+from perturbo.sparse_design import (
+    IndexedDesignMatrix,
+    design_values_are_finite_nonnegative,
+    indexed_design_from_matrix,
+)
 
 VALID_CLI_SIZE_FACTOR_MODES = ("infer", "observed", "none")
 
@@ -77,14 +82,14 @@ class SVIConfig:
 @dataclass
 class PerTurboData:
     counts: jnp.ndarray
-    pert_id: jnp.ndarray
+    pert_id: jnp.ndarray | IndexedDesignMatrix
     pert_names: list[str]
     gene_names: list[str]
     cell_mask: jnp.ndarray | None = None
     size_factors: jnp.ndarray | None = None
     covariates: jnp.ndarray | None = None
     covariate_names: list[str] | None = None
-    guide_matrix: jnp.ndarray | None = None
+    guide_matrix: jnp.ndarray | IndexedDesignMatrix | None = None
     guide_names: list[str] | None = None
     guide_to_element: jnp.ndarray | None = None
     library_size_center_log_mean: float | None = None
@@ -177,6 +182,41 @@ class CovariateTransformState:
     all_feature_names: list[str]
     feature_names: list[str]
     dropped_features: list[str]
+
+
+def subset_control_fit_genes(control_fit: ControlFit, gene_indices: slice | Iterable[int]) -> ControlFit:
+    """Return stage-one quantities aligned to one expression-gene chunk."""
+    index = gene_indices
+
+    def take(values, axis: int = 0):
+        if values is None:
+            return None
+        return jnp.take(jnp.asarray(values), np.arange(values.shape[axis])[index], axis=axis)
+
+    baseline = control_fit.baseline_posterior
+    if baseline is not None:
+        baseline = BaselinePosteriorSummary(
+            beta_0_loc=take(baseline.beta_0_loc),
+            beta_0_scale=take(baseline.beta_0_scale),
+            theta_log_loc=take(baseline.theta_log_loc),
+            theta_log_scale=take(baseline.theta_log_scale),
+        )
+    return replace(
+        control_fit,
+        beta_0=take(control_fit.beta_0),
+        theta=take(control_fit.theta),
+        noise_scale=take(control_fit.noise_scale),
+        factor_loadings=take(control_fit.factor_loadings, axis=-1),
+        factor_center=take(control_fit.factor_center),
+        pca_loadings=take(control_fit.pca_loadings, axis=-1),
+        baseline_posterior=baseline,
+        pi_outlier=take(control_fit.pi_outlier),
+        theta_outlier=take(control_fit.theta_outlier),
+        outlier_mean_shift=take(control_fit.outlier_mean_shift),
+        covariate_coef=take(control_fit.covariate_coef, axis=-1),
+        guide_random_effect_tau=take(control_fit.guide_random_effect_tau),
+        count_censoring_threshold=take(control_fit.count_censoring_threshold),
+    )
 
 
 def _resolve_cli_size_factor_mode(*, size_factor_mode: str, use_observed_size_factors: bool) -> str:
@@ -658,6 +698,28 @@ def _to_jax(x: Any, device: Any | None, dtype: Any | None = None) -> jnp.ndarray
     return arr
 
 
+def _indexed_design_to_device(design: IndexedDesignMatrix, device: Any | None) -> IndexedDesignMatrix:
+    return IndexedDesignMatrix(
+        indices=_to_jax(design.indices, device, dtype=jnp.int32),
+        values=_to_jax(design.values, device, dtype=jnp.float32),
+        num_columns=design.num_columns,
+    )
+
+
+def _design_row_has_activity(design: Any) -> np.ndarray:
+    if isinstance(design, IndexedDesignMatrix):
+        return np.any(np.asarray(design.values) != 0, axis=1)
+    if sp.issparse(design):
+        return np.asarray((design != 0).sum(axis=1)).reshape(-1) > 0
+    return np.asarray(design).sum(axis=1) > 0
+
+
+def _take_design_rows(design: Any, rows) -> Any:
+    if isinstance(design, IndexedDesignMatrix):
+        return design.take_rows(rows)
+    return design[rows]
+
+
 def _dedupe_preserve_order(values: list[str] | None) -> list[str]:
     if values is None:
         return []
@@ -674,11 +736,12 @@ def _dedupe_preserve_order(values: list[str] | None) -> list[str]:
 
 def _load_observed_size_factors(
     obs: pd.DataFrame,
-    counts: jnp.ndarray,
+    counts: Any,
     *,
     size_factor_key: str | None = None,
     library_size_key: str | None = None,
     library_size_center_log_mean: float | None = None,
+    counts_library_sizes: np.ndarray | None = None,
 ) -> tuple[jnp.ndarray | None, float | None]:
     if size_factor_key is not None and size_factor_key in obs.columns:
         values = pd.to_numeric(obs[size_factor_key], errors="coerce").to_numpy(dtype=np.float32)
@@ -715,15 +778,24 @@ def _load_observed_size_factors(
             log_mean = float(library_size_center_log_mean)
         size_factors = (log_lib - log_mean).astype(np.float32, copy=False)[:, None]
         return jnp.asarray(size_factors, dtype=jnp.float32), log_mean
-    if counts is not None and hasattr(counts, "sum") and library_size_key is None and size_factor_key is None:
-        # No key named: the library size is the cell's total over the analysed genes.
-        # That is what --library-size-key usually holds anyway, computed over the full
-        # panel; over a gene subset it is the same quantity restricted to the subset.
-        totals = np.asarray(counts.sum(axis=1), dtype=np.float64).reshape(-1)
-        if totals.size and np.all(totals > 0):
+    if library_size_key is None and size_factor_key is None:
+        totals = counts_library_sizes
+        if totals is None and counts is not None and hasattr(counts, "sum"):
+            totals = np.asarray(counts.sum(axis=1), dtype=np.float64).reshape(-1)
+        if totals is not None:
+            totals = np.asarray(totals, dtype=np.float64).reshape(-1)
+            if np.any(~np.isfinite(totals)) or np.any(totals < 0):
+                raise ValueError("Counts-derived library sizes must be finite and non-negative.")
             log_lib = np.log1p(totals)
-            log_mean = float(np.mean(log_lib)) if library_size_center_log_mean is None else float(library_size_center_log_mean)
-            print("[perturbo] No --library-size-key given: using each cell's total count over the analysed genes as its library size.")
+            log_mean = (
+                float(np.mean(log_lib))
+                if library_size_center_log_mean is None
+                else float(library_size_center_log_mean)
+            )
+            print(
+                "[perturbo] No --library-size-key given: using each cell's total count over the full "
+                "analysis panel as its library size."
+            )
             return jnp.asarray((log_lib - log_mean).astype(np.float32)[:, None], dtype=jnp.float32), log_mean
     return None, None
 
@@ -966,7 +1038,9 @@ def _select_count_dtype(counts: np.ndarray) -> np.dtype:
     return np.int64
 
 
-def _infer_num_perts(pert_id: jnp.ndarray) -> int:
+def _infer_num_perts(pert_id: jnp.ndarray | IndexedDesignMatrix) -> int:
+    if isinstance(pert_id, IndexedDesignMatrix):
+        return int(pert_id.num_columns)
     arr = jnp.asarray(pert_id)
     if arr.ndim == 1:
         return int(jnp.max(arr)) + 1
@@ -1005,6 +1079,32 @@ def _resolve_adata(data, modality_key: str | None):
             raise KeyError(f"modality_key '{modality_key}' not found in MuData.mod. Available modalities: {available}")
         return data.mod[modality_key]
     return data
+
+
+def _positive_counts_per_row_bounded(
+    matrix: Any,
+    *,
+    column_indices: np.ndarray | None = None,
+    row_chunk_size: int = BACKED_ROW_CHUNK_SIZE,
+) -> np.ndarray:
+    """Count positive entries per row for dense, sparse, or backed matrices."""
+    if row_chunk_size < 1:
+        raise ValueError("row_chunk_size must be positive.")
+    num_rows = int(matrix.shape[0])
+    counts = np.empty(num_rows, dtype=np.int32)
+    columns = None if column_indices is None else np.asarray(column_indices, dtype=np.int64)
+    for start in range(0, num_rows, row_chunk_size):
+        stop = min(start + row_chunk_size, num_rows)
+        block = matrix[start:stop]
+        if columns is not None:
+            block = block[:, columns]
+        if sp.issparse(block) or hasattr(block, "tocsr"):
+            row_counts = np.asarray((block > 0).sum(axis=1)).reshape(-1)
+        else:
+            row_counts = np.asarray(block) > 0
+            row_counts = row_counts.sum(axis=1)
+        counts[start:stop] = np.asarray(row_counts, dtype=np.int32)
+    return counts
 
 
 def measure_realized_moi(
@@ -1048,10 +1148,7 @@ def measure_realized_moi(
 
     pert_adata = _resolve_perturbation_modality(data, perturbation_modality_key)
     matrix = _get_layer_matrix(pert_adata, perturbation_layer)
-    if hasattr(matrix, "tocsr"):
-        per_cell = np.asarray((matrix > 0).sum(axis=1)).reshape(-1)
-    else:
-        per_cell = np.asarray(np.asarray(matrix) > 0).sum(axis=1).reshape(-1)
+    per_cell = _positive_counts_per_row_bounded(matrix)
     per_cell = per_cell.astype(np.float64)
     n_control = int(np.sum(per_cell == 0))
     if control_substring is not None:
@@ -1062,8 +1159,10 @@ def measure_realized_moi(
         is_control_guide = np.char.find(names, str(control_substring)) >= 0
         if perturbation_element_varm_key is not None and perturbation_element_varm_key in pert_adata.varm:
             mapping = pert_adata.varm[perturbation_element_varm_key]
-            mapping = mapping.to_numpy() if hasattr(mapping, "to_numpy") else mapping
-            mapping = mapping.toarray() if hasattr(mapping, "toarray") else np.asarray(mapping)
+            if hasattr(mapping, "to_numpy"):
+                mapping = mapping.to_numpy()
+            elif not sp.issparse(mapping):
+                mapping = np.asarray(mapping)
             element_names = None
             if perturbation_element_names_uns_key is not None and perturbation_element_names_uns_key in pert_adata.uns:
                 element_names = np.asarray(pert_adata.uns[perturbation_element_names_uns_key], dtype=str)
@@ -1071,10 +1170,12 @@ def measure_realized_moi(
                 element_names = np.asarray(pert_adata.varm[perturbation_element_varm_key].columns, dtype=str)
             if element_names is not None and element_names.size == mapping.shape[1]:
                 control_elements = np.char.find(element_names, str(control_substring)) >= 0
-                is_control_guide |= np.asarray(mapping[:, control_elements].sum(axis=1)).reshape(-1) > 0
+                is_control_guide |= np.asarray((mapping[:, control_elements] > 0).sum(axis=1)).reshape(-1) > 0
         if is_control_guide.any():
-            control_matrix = matrix[:, np.flatnonzero(is_control_guide)]
-            carried = np.asarray((control_matrix > 0).sum(axis=1)).reshape(-1)
+            carried = _positive_counts_per_row_bounded(
+                matrix,
+                column_indices=np.flatnonzero(is_control_guide),
+            )
             # A cell counts as a control when everything it carries is a control guide.
             n_control = int(np.sum((carried > 0) & (carried == per_cell)))
     return {
@@ -1117,7 +1218,8 @@ def _load_perturbation_matrix(
     perturbation_layer: str | None,
     obs_names,
     pert_subset: list[str] | None = None,
-) -> tuple[np.ndarray, list[str]]:
+    indexed_design: bool = False,
+) -> tuple[Any, list[str]]:
     pert_adata = _resolve_perturbation_modality(data, perturbation_modality_key)
     if obs_names is not None:
         pert_adata = pert_adata[obs_names]
@@ -1129,9 +1231,10 @@ def _load_perturbation_matrix(
         if missing:
             raise KeyError(f"Perturbations not found in perturbation modality: {missing}")
         col_idx = [name_to_idx[name] for name in pert_subset]
+        _validate_exact_perturbation_subset(matrix, col_idx, label="perturbations")
         matrix = matrix[:, col_idx]
         pert_names = list(pert_subset)
-    return _to_dense(matrix), pert_names
+    return (indexed_design_from_matrix(matrix) if indexed_design else matrix), pert_names
 
 
 def _resolve_element_names(
@@ -1177,7 +1280,8 @@ def _load_perturbation_element_mapping(
     perturbation_modality_key: str,
     perturbation_element_varm_key: str,
     perturbation_element_names_uns_key: str | None,
-) -> tuple[np.ndarray, list[str]]:
+    preserve_sparse: bool = False,
+) -> tuple[Any, list[str]]:
     pert_adata = _resolve_perturbation_modality(data, perturbation_modality_key)
     if perturbation_element_varm_key not in pert_adata.varm:
         available_varm = list(pert_adata.varm.keys())
@@ -1186,8 +1290,10 @@ def _load_perturbation_element_mapping(
             f"mdata['{perturbation_modality_key}'].varm. Available keys: {available_varm}"
         )
     element_mapping_raw = pert_adata.varm[perturbation_element_varm_key]
-    if hasattr(element_mapping_raw, "toarray") or hasattr(element_mapping_raw, "A"):
-        element_mapping = _to_dense(element_mapping_raw)
+    if sp.issparse(element_mapping_raw):
+        element_mapping = element_mapping_raw.tocsr() if preserve_sparse else element_mapping_raw.toarray()
+    elif hasattr(element_mapping_raw, "to_numpy"):
+        element_mapping = element_mapping_raw.to_numpy()
     else:
         element_mapping = np.asarray(element_mapping_raw)
     if element_mapping.ndim != 2:
@@ -1207,28 +1313,46 @@ def _load_perturbation_element_mapping(
         perturbation_element_names_uns_key=perturbation_element_names_uns_key,
         n_elements=element_mapping.shape[1],
     )
+    if sp.issparse(element_mapping):
+        return (element_mapping > 0).astype(np.int8).tocsr(), element_names
     return np.asarray(element_mapping > 0, dtype=np.int8), element_names
 
 
 def _group_perturbation_matrix_by_element(
     perturbation_matrix: Any,
     element_mapping: np.ndarray,
-) -> np.ndarray:
-    # A guide assignment is sparse (a cell carries a handful of guides), so the
-    # cells-by-elements indicator is a sparse product. The dense int8 product this
-    # used to compute has no BLAS kernel: on the Replogle pipeline input
-    # (233,253 cells x 2,231 guides x 2,108 elements) numpy's generic loop ran for
-    # hours on one core, which is where every pipeline run spent its afternoon.
-    from scipy import sparse as _sparse
+    *,
+    preserve_sparse: bool = False,
+) -> np.ndarray | sp.csr_matrix:
+    # Sparse multiplication is essential even when the input is a dense array:
+    # guide assignments have few positives per cell, and dense integer matmul
+    # has no BLAS kernel. Keep a compact result until callers select their rows
+    # and columns; int32 accumulation also avoids duplicate-guide overflow.
+    mapping = sp.csr_matrix(element_mapping > 0, dtype=np.int32)
+    indicator = sp.csr_matrix(perturbation_matrix > 0, dtype=np.int32)
+    grouped = (indicator @ mapping).tocsr()
+    grouped.data = np.asarray(grouped.data > 0, dtype=np.int8)
+    grouped.eliminate_zeros()
+    return grouped if preserve_sparse else grouped.toarray()
 
-    mapping = _sparse.csr_matrix(np.asarray(element_mapping > 0, dtype=np.float32))
-    if _sparse.issparse(perturbation_matrix):
-        indicator = perturbation_matrix.tocsr().astype(np.float32)
-        indicator.data[:] = (indicator.data > 0).astype(np.float32)
-    else:
-        indicator = _sparse.csr_matrix(np.asarray(perturbation_matrix > 0, dtype=np.float32))
-    grouped = indicator @ mapping
-    return np.asarray((grouped > 0).toarray(), dtype=np.int8)
+
+def _validate_exact_perturbation_subset(matrix: Any, selected_columns: list[int], *, label: str) -> None:
+    """Reject target-axis chunks with omitted active predictors on retained rows."""
+    num_columns = int(matrix.shape[1])
+    selected = np.zeros(num_columns, dtype=bool)
+    selected[np.asarray(selected_columns, dtype=np.int64)] = True
+    if selected.all() or not selected.any():
+        return
+    selected_rows = np.asarray((matrix[:, selected] != 0).sum(axis=1)).reshape(-1) > 0
+    if not selected_rows.any():
+        return
+    excluded_on_selected_rows = np.asarray((matrix[selected_rows][:, ~selected] != 0).sum(axis=1)).reshape(-1) > 0
+    if np.any(excluded_on_selected_rows):
+        count = int(np.count_nonzero(excluded_on_selected_rows))
+        raise ValueError(
+            f"Cannot fit selected {label} exactly: {count} retained cell(s) also carry excluded effects. "
+            "Use gene-axis chunking so every co-occurring predictor remains in the fitted model."
+        )
 
 
 def _load_grouped_perturbation_matrix(
@@ -1240,7 +1364,8 @@ def _load_grouped_perturbation_matrix(
     perturbation_element_names_uns_key: str | None,
     obs_names,
     pert_subset: list[str] | None = None,
-) -> tuple[np.ndarray, list[str]]:
+    indexed_design: bool = False,
+) -> tuple[Any, list[str]]:
     pert_adata = _resolve_perturbation_modality(data, perturbation_modality_key)
     if obs_names is not None:
         pert_adata = pert_adata[obs_names]
@@ -1250,17 +1375,19 @@ def _load_grouped_perturbation_matrix(
         perturbation_modality_key=perturbation_modality_key,
         perturbation_element_varm_key=perturbation_element_varm_key,
         perturbation_element_names_uns_key=perturbation_element_names_uns_key,
+        preserve_sparse=True,
     )
-    grouped = _group_perturbation_matrix_by_element(matrix, element_mapping)
+    grouped = _group_perturbation_matrix_by_element(matrix, element_mapping, preserve_sparse=True)
     if pert_subset is not None:
         name_to_idx = {name: idx for idx, name in enumerate(element_names)}
         missing = [name for name in pert_subset if name not in name_to_idx]
         if missing:
             raise KeyError(f"Grouped perturbation elements not found: {missing}")
         col_idx = [name_to_idx[name] for name in pert_subset]
+        _validate_exact_perturbation_subset(grouped, col_idx, label="perturbation elements")
         grouped = grouped[:, col_idx]
         element_names = list(pert_subset)
-    return grouped, element_names
+    return (indexed_design_from_matrix(grouped) if indexed_design else grouped), element_names
 
 
 def _load_guide_shared_perturbation_data(
@@ -1272,7 +1399,8 @@ def _load_guide_shared_perturbation_data(
     perturbation_element_names_uns_key: str | None,
     obs_names,
     element_subset: list[str] | None = None,
-) -> tuple[np.ndarray, list[str], np.ndarray, np.ndarray, list[str]]:
+    indexed_design: bool = False,
+) -> tuple[Any, list[str], Any, np.ndarray, list[str]]:
     pert_adata = _resolve_perturbation_modality(data, perturbation_modality_key)
     if obs_names is not None:
         pert_adata = pert_adata[obs_names]
@@ -1283,26 +1411,32 @@ def _load_guide_shared_perturbation_data(
         perturbation_modality_key=perturbation_modality_key,
         perturbation_element_varm_key=perturbation_element_varm_key,
         perturbation_element_names_uns_key=perturbation_element_names_uns_key,
+        preserve_sparse=True,
     )
+    grouped = _group_perturbation_matrix_by_element(raw_matrix, element_mapping, preserve_sparse=True)
     if element_subset is not None:
         name_to_idx = {name: idx for idx, name in enumerate(all_element_names)}
         missing = [name for name in element_subset if name not in name_to_idx]
         if missing:
             raise KeyError(f"Grouped perturbation elements not found: {missing}")
         col_idx = [name_to_idx[name] for name in element_subset]
-        guide_mask = np.asarray(element_mapping[:, col_idx].sum(axis=1) > 0, dtype=bool)
+        _validate_exact_perturbation_subset(grouped, col_idx, label="perturbation elements")
+        guide_mask = np.asarray(element_mapping[:, col_idx].sum(axis=1) > 0, dtype=bool).reshape(-1)
         raw_matrix = raw_matrix[:, guide_mask]
         element_mapping = element_mapping[guide_mask][:, col_idx]
+        grouped = grouped[:, col_idx]
         guide_names = [name for name, keep in zip(guide_names, guide_mask, strict=True) if keep]
         element_names = list(element_subset)
     else:
         element_names = list(all_element_names)
-    grouped = _group_perturbation_matrix_by_element(raw_matrix, element_mapping)
     return (
-        _to_dense(raw_matrix),
+        indexed_design_from_matrix(raw_matrix) if indexed_design else raw_matrix,
         guide_names,
-        grouped,
-        np.asarray(element_mapping > 0, dtype=np.float32),
+        indexed_design_from_matrix(grouped) if indexed_design else grouped,
+        np.asarray(
+            (element_mapping > 0).toarray() if sp.issparse(element_mapping) else element_mapping > 0,
+            dtype=np.float32,
+        ),
         element_names,
     )
 
@@ -1505,6 +1639,92 @@ def _extract_gene_names(adata, gene_name_key: str | None) -> list[str]:
     return adata.var.index.astype(str).tolist()
 
 
+def _normalize_gene_indices(selected_gene_indices, num_genes: int) -> np.ndarray | slice:
+    if selected_gene_indices is None:
+        return slice(None)
+    if isinstance(selected_gene_indices, slice):
+        start, stop, step = selected_gene_indices.indices(num_genes)
+        if step != 1:
+            return np.arange(start, stop, step, dtype=np.int64)
+        return slice(start, stop)
+    indices = np.asarray(selected_gene_indices)
+    if indices.ndim != 1:
+        raise ValueError("selected_gene_indices must be a one-dimensional sequence or slice.")
+    if indices.dtype == bool:
+        if indices.shape != (num_genes,):
+            raise ValueError("A boolean selected_gene_indices mask must match the full gene count.")
+        indices = np.flatnonzero(indices)
+    indices = np.asarray(indices, dtype=np.int64)
+    if indices.size and (np.any(indices < 0) or np.any(indices >= num_genes)):
+        raise IndexError("selected_gene_indices contains an index outside the full gene panel.")
+    if np.unique(indices).size != indices.size:
+        raise ValueError("selected_gene_indices must not contain duplicate indices.")
+    return indices
+
+
+def _sum_matrix_rows_bounded(matrix, row_indices: np.ndarray, *, row_chunk_size: int = BACKED_ROW_CHUNK_SIZE) -> np.ndarray:
+    """Sum selected matrix rows without materializing their full gene panel."""
+    if row_chunk_size < 1:
+        raise ValueError("row_chunk_size must be positive.")
+    rows = np.asarray(row_indices, dtype=np.int64)
+    totals = np.empty(rows.size, dtype=np.float64)
+    for start in range(0, rows.size, row_chunk_size):
+        stop = min(start + row_chunk_size, rows.size)
+        block = matrix[rows[start:stop], :]
+        totals[start:stop] = np.asarray(block.sum(axis=1), dtype=np.float64).reshape(-1)
+    return totals
+
+
+def _load_dense_matrix_slice_bounded(
+    matrix: Any,
+    row_indices: np.ndarray,
+    column_indices: slice | np.ndarray,
+    *,
+    row_chunk_size: int = 2_048,
+) -> np.ndarray:
+    """Read a backed matrix slice without loading every selected row at once."""
+    if row_chunk_size < 1:
+        raise ValueError("row_chunk_size must be positive.")
+    rows = np.asarray(row_indices, dtype=np.int64)
+    columns = np.arange(int(matrix.shape[1]), dtype=np.int64)[column_indices]
+    result = np.empty((rows.size, columns.size), dtype=matrix.dtype)
+    for start in range(0, rows.size, row_chunk_size):
+        stop = min(start + row_chunk_size, rows.size)
+        block_rows = rows[start:stop]
+        if block_rows.size and np.array_equal(
+            block_rows,
+            np.arange(int(block_rows[0]), int(block_rows[-1]) + 1, dtype=np.int64),
+        ):
+            row_selector: slice | np.ndarray = slice(int(block_rows[0]), int(block_rows[-1]) + 1)
+        else:
+            row_selector = block_rows
+        # Backed CSR indexing reads the selected rows' compressed vectors before
+        # applying a column slice. Bound that temporary by rows, then select the
+        # requested genes while the block is in memory.
+        block = matrix[row_selector, :]
+        block = block[:, column_indices]
+        if hasattr(block, "toarray"):
+            block = block.toarray()
+        result[start:stop] = np.asarray(block)
+    return result
+
+
+def _select_library_sizes_for_rows(
+    full_panel_library_sizes: np.ndarray,
+    *,
+    source_num_cells: int,
+    selected_rows: np.ndarray,
+) -> np.ndarray:
+    totals = np.asarray(full_panel_library_sizes, dtype=np.float64).reshape(-1)
+    if totals.shape[0] == source_num_cells:
+        return totals[selected_rows]
+    if totals.shape[0] == selected_rows.size:
+        return totals
+    raise ValueError(
+        "full_panel_library_sizes must have one value per source cell or one value per selected analysis cell."
+    )
+
+
 def _validate_cli_input_keys(
     data,
     *,
@@ -1623,11 +1843,10 @@ def load_controls(
 ) -> PerTurboData | tuple[PerTurboData, CovariateTransformState | None]:
     print("[perturbo] Loading controls...")
     adata = _resolve_adata(data, modality_key)
-    is_backed = getattr(adata, "isbacked", False)
 
     # Compose all obs-level filters into a single integer index array before
-    # touching adata.X.  Backed AnnData forbids "view of a view", so we must
-    # perform exactly one adata[...] slice (followed by .copy() to materialise).
+    # touching adata.X. Backed AnnData forbids "view of a view", so compose the
+    # row selection before creating the single metadata/count view below.
     if cell_keep_mask is not None:
         keep_arr = np.asarray(cell_keep_mask, dtype=bool)
         if keep_arr.shape != (adata.n_obs,):
@@ -1644,7 +1863,9 @@ def load_controls(
         pert_adata = _resolve_perturbation_modality(data, perturbation_modality_key)
         if working_obs_names is not None:
             pert_adata = pert_adata[working_obs_names]
-        pert_id = _to_dense(_get_layer_matrix(pert_adata, perturbation_layer))
+        # Keep a sparse perturbation matrix sparse while selecting and
+        # subsampling controls. It is densified only after the control cap.
+        pert_id = _get_layer_matrix(pert_adata, perturbation_layer)
         pert_names = _extract_pert_names(pert_adata)
         guide_to_element = None
         element_names = None
@@ -1680,7 +1901,7 @@ def load_controls(
                     "beside a targeting one are treated as perturbed, not as controls."
                 )
             obs_idx = obs_idx[mask]
-            pert_id = np.asarray(pert_id)[np.ix_(mask, control_cols)]
+            pert_id = pert_id[mask][:, control_cols]
             pert_names = [n for n, c in zip(pert_names, control_cols) if c]
     else:
         if perturbation_key is None:
@@ -1693,13 +1914,11 @@ def load_controls(
         subsample = np.sort(rng.choice(len(obs_idx), size=max_control_cells, replace=False))
         obs_idx = obs_idx[subsample]
         if use_matrix:
-            pert_id = np.asarray(pert_id)[subsample]
+            pert_id = pert_id[subsample]
         print(f"[perturbo] Subsampled controls to {max_control_cells} cells.")
 
     # Single slice: for backed data this is one targeted disk read.
     adata = adata[obs_idx]
-    if is_backed:
-        adata = adata.to_memory()
 
     if not use_matrix:
         gene_names, pert_names, pert_id = _extract_names(adata, gene_name_key, perturbation_key)
@@ -1739,7 +1958,7 @@ def load_controls(
             )
         covariates = _to_jax(cov_matrix, device_obj, dtype=jnp.float32)
     print("[perturbo] Controls prepared for JAX.")
-    pert_id_arr = np.asarray(pert_id)
+    pert_id_arr = np.asarray(_to_dense(pert_id))
     pert_dtype = jnp.bool_ if pert_id_arr.ndim == 2 else None
     out = PerTurboData(
         counts=counts_jax,
@@ -1780,15 +1999,18 @@ def load_analysis_cells(
     covariate_transform_state: CovariateTransformState | None = None,
     retain_guide_structure: bool = False,
     library_size_center_log_mean: float | None = None,
+    selected_gene_indices: slice | Iterable[int] | np.ndarray | None = None,
+    full_panel_library_sizes: np.ndarray | None = None,
+    indexed_perturbation_design: bool = False,
 ) -> PerTurboData:
     subset_suffix = " for selected perturbations" if selected_perturbations is not None else ""
     print(f"[perturbo] Loading analysis cells{subset_suffix}...")
     adata = _resolve_adata(data, modality_key)
-    is_backed = getattr(adata, "isbacked", False)
+    is_backed = bool(getattr(adata, "isbacked", False))
 
     # Compose all obs-level filters into a single integer index array before
-    # touching adata.X.  Backed AnnData forbids "view of a view", so we must
-    # perform exactly one adata[...] slice (followed by .copy() to materialise).
+    # touching adata.X. Backed AnnData forbids "view of a view", so compose the
+    # row selection before creating the single metadata/count view below.
     if cell_keep_mask is not None:
         keep_arr = np.asarray(cell_keep_mask, dtype=bool)
         if keep_arr.shape != (adata.n_obs,):
@@ -1816,12 +2038,13 @@ def load_analysis_cells(
                 perturbation_element_names_uns_key=perturbation_element_names_uns_key,
                 obs_names=working_obs_names,
                 element_subset=selected_perturbations,
+                indexed_design=indexed_perturbation_design,
             )
             if selected_perturbations is not None:
-                mask = np.asarray(pert_id).sum(axis=1) > 0
+                mask = _design_row_has_activity(pert_id)
                 obs_idx = obs_idx[mask]
-                pert_id = pert_id[mask]
-                guide_matrix = guide_matrix[mask]
+                pert_id = _take_design_rows(pert_id, mask)
+                guide_matrix = _take_design_rows(guide_matrix, mask)
         elif perturbation_element_varm_key is not None:
             pert_id, pert_names = _load_grouped_perturbation_matrix(
                 data,
@@ -1831,11 +2054,12 @@ def load_analysis_cells(
                 perturbation_element_names_uns_key=perturbation_element_names_uns_key,
                 obs_names=working_obs_names,
                 pert_subset=selected_perturbations,
+                indexed_design=indexed_perturbation_design,
             )
             if selected_perturbations is not None:
-                mask = np.asarray(pert_id).sum(axis=1) > 0
+                mask = _design_row_has_activity(pert_id)
                 obs_idx = obs_idx[mask]
-                pert_id = pert_id[mask]
+                pert_id = _take_design_rows(pert_id, mask)
         else:
             pert_id, pert_names = _load_perturbation_matrix(
                 data,
@@ -1843,11 +2067,12 @@ def load_analysis_cells(
                 perturbation_layer=perturbation_layer,
                 obs_names=working_obs_names,
                 pert_subset=selected_perturbations,
+                indexed_design=indexed_perturbation_design,
             )
             if selected_perturbations is not None:
-                mask = np.asarray(pert_id).sum(axis=1) > 0
+                mask = _design_row_has_activity(pert_id)
                 obs_idx = obs_idx[mask]
-                pert_id = pert_id[mask]
+                pert_id = _take_design_rows(pert_id, mask)
     else:
         if perturbation_key is None:
             raise ValueError("perturbation_key must be provided for obs-based perturbations.")
@@ -1855,10 +2080,30 @@ def load_analysis_cells(
             mask = working_obs[perturbation_key].astype(str).isin(selected_perturbations).values
             obs_idx = obs_idx[mask]
 
-    # Single slice: for backed data this is one targeted disk read.
-    adata = adata[obs_idx]
-    if is_backed:
-        adata = adata.to_memory()
+    gene_indices = _normalize_gene_indices(selected_gene_indices, adata.n_vars)
+    counts_library_sizes = None
+    if size_factor_key is None and library_size_key is None:
+        if full_panel_library_sizes is not None:
+            counts_library_sizes = _select_library_sizes_for_rows(
+                full_panel_library_sizes,
+                source_num_cells=adata.n_obs,
+                selected_rows=obs_idx,
+            )
+        elif selected_gene_indices is not None:
+            counts_library_sizes = _sum_matrix_rows_bounded(_get_layer_matrix(adata, None), obs_idx)
+
+    # One compound slice ensures backed AnnData reads only the requested rows
+    # and gene chunk. Accessing ``adata.X`` below materializes that matrix slice
+    # alone; converting the whole AnnData view to memory would also load its
+    # unsliced ``.raw`` matrix and unrelated layers.
+    counts = None
+    if is_backed and selected_gene_indices is not None:
+        counts = _load_dense_matrix_slice_bounded(
+            _get_layer_matrix(adata, None),
+            obs_idx,
+            gene_indices,
+        )
+    adata = adata[obs_idx, gene_indices]
 
     if use_matrix:
         gene_names = _extract_gene_names(adata, gene_name_key)
@@ -1869,9 +2114,13 @@ def load_analysis_cells(
             perturbation_key,
             pert_names_override=selected_perturbations,
         )
-    counts = _to_dense(adata.X)
+    if counts is None:
+        counts = _to_dense(adata.X)
     if winsorize_gene_expression:
-        counts = _winsorize_counts_to_gene_thresholds(counts, gene_clip_thresholds)
+        selected_thresholds = gene_clip_thresholds
+        if gene_clip_thresholds is not None and selected_gene_indices is not None:
+            selected_thresholds = np.asarray(gene_clip_thresholds)[gene_indices]
+        counts = _winsorize_counts_to_gene_thresholds(counts, selected_thresholds)
     count_dtype = _select_count_dtype(counts)
 
     print(f"[perturbo] Analysis cells loaded: {adata.n_obs} cells, {adata.n_vars} genes")
@@ -1884,6 +2133,7 @@ def load_analysis_cells(
         size_factor_key=size_factor_key,
         library_size_key=library_size_key,
         library_size_center_log_mean=library_size_center_log_mean,
+        counts_library_sizes=counts_library_sizes,
     )
     covariates = None
     covariate_names = None
@@ -1912,17 +2162,29 @@ def load_analysis_cells(
                 )
             covariates = _to_jax(cov_matrix, device_obj, dtype=jnp.float32)
     print("[perturbo] Analysis cells prepared for JAX.")
-    pert_id_arr = np.asarray(pert_id)
-    pert_dtype = jnp.bool_ if pert_id_arr.ndim == 2 else None
+    if isinstance(pert_id, IndexedDesignMatrix):
+        pert_id_jax = _indexed_design_to_device(pert_id, device_obj)
+    else:
+        pert_id_arr = np.asarray(_to_dense(pert_id))
+        pert_dtype = jnp.bool_ if pert_id_arr.ndim == 2 else None
+        pert_id_jax = _to_jax(pert_id_arr, device_obj, dtype=pert_dtype)
+    if isinstance(guide_matrix, IndexedDesignMatrix):
+        guide_matrix_jax = _indexed_design_to_device(guide_matrix, device_obj)
+    else:
+        guide_matrix_jax = (
+            _to_jax(_to_dense(guide_matrix), device_obj, dtype=jnp.float32)
+            if guide_matrix is not None
+            else None
+        )
     return PerTurboData(
         counts=counts_jax,
-        pert_id=_to_jax(pert_id_arr, device_obj, dtype=pert_dtype),
+        pert_id=pert_id_jax,
         pert_names=pert_names,
         gene_names=gene_names,
         size_factors=_to_jax(size_factors, device_obj, dtype=jnp.float32) if size_factors is not None else None,
         covariates=covariates,
         covariate_names=covariate_names,
-        guide_matrix=_to_jax(guide_matrix, device_obj, dtype=jnp.float32) if guide_matrix is not None else None,
+        guide_matrix=guide_matrix_jax,
         guide_names=guide_names,
         guide_to_element=(
             _to_jax(np.asarray(guide_to_element), device_obj, dtype=jnp.float32)
@@ -2363,19 +2625,24 @@ def fit_perturbation_effects(
             raise ValueError(
                 "fit_perturbation_dispersion=True is currently supported only for negative-binomial likelihoods."
             )
-        pert_array = np.asarray(pert_id)
-        if pert_array.ndim not in {1, 2}:
+        pert_ndim = pert_id.ndim
+        if pert_ndim not in {1, 2}:
             raise ValueError("fit_perturbation_dispersion=True requires 1D or 2D perturbation labels.")
         if has_guide_mapping:
-            guide_array = np.asarray(data.guide_matrix)
-            if guide_array.ndim != 2 or np.any(~np.isfinite(guide_array)) or np.any(guide_array < 0):
+            if data.guide_matrix.ndim != 2 or not design_values_are_finite_nonnegative(data.guide_matrix):
                 raise ValueError("High-MOI guide_matrix must be a finite, non-negative 2D matrix.")
-        elif pert_array.ndim == 2 and (
-            np.any(pert_array < 0) or np.any(np.asarray(pert_array.sum(axis=1)).reshape(-1) > 1)
-        ):
-            raise ValueError(
-                "Without guide-level inputs, fit_perturbation_dispersion=True requires at most one active perturbation per cell."
-            )
+        elif pert_ndim == 2:
+            if isinstance(pert_id, IndexedDesignMatrix):
+                row_totals = np.asarray(pert_id.values).sum(axis=1)
+                invalid = not design_values_are_finite_nonnegative(pert_id) or np.any(row_totals > 1)
+            else:
+                pert_array = np.asarray(pert_id)
+                invalid = np.any(pert_array < 0) or np.any(np.asarray(pert_array.sum(axis=1)).reshape(-1) > 1)
+            if invalid:
+                raise ValueError(
+                    "Without guide-level inputs, fit_perturbation_dispersion=True requires at most one active "
+                    "perturbation per cell."
+                )
         if not np.isfinite(perturbation_dispersion_prior_rate) or perturbation_dispersion_prior_rate <= 0:
             raise ValueError("perturbation_dispersion_prior_rate must be finite and > 0.")
     model_cls = _resolve_guide_shared_model(model_name) if use_guide_shared_model else _resolve_model(model_name)

--- a/src/perturbo/crt.py
+++ b/src/perturbo/crt.py
@@ -60,6 +60,7 @@ import jax.numpy as jnp
 import numpy as np
 
 from perturbo.core import PerTurboData, ControlFit, _normalize_likelihood_name
+from perturbo.sparse_design import IndexedDesignMatrix
 from perturbo._internal.chunked_runner import iter_gene_chunks, replace_gene_axis
 from perturbo._internal.low_moi.design import prepare_low_moi_design
 from perturbo._internal.parametric_null import (
@@ -79,6 +80,7 @@ from perturbo.utils import compute_size_factors
 
 __all__ = [
     "BaselineNullCheck",
+    "AllCellsPropensityFit",
     "ChunkCRTResult",
     "ControlBlock",
     "ControlNuisance",
@@ -99,6 +101,7 @@ __all__ = [
     "control_block_for_genes",
     "exclude_targets",
     "prepare_crt_baseline",
+    "prepare_all_cells_propensity",
     "polish_baseline_to_null_mode",
     "run_crt_for_chunk",
     "run_crt_all_cells",
@@ -262,7 +265,11 @@ def assemble_control_nuisance(
     size-factor mode those are zeros and this is still correct.
     """
 
-    counts = np.asarray(control_data.counts, dtype=np.float64)
+    # Keep the source dtype here. The baseline owns this panel for the whole
+    # CRT run, and eagerly widening a float32 count matrix to float64 doubles
+    # its resident CPU footprint. Numerical kernels cast only the active gene
+    # block to float64 when they need diagnostic precision.
+    counts = np.asarray(control_data.counts)
     if counts.ndim != 2:
         raise ValueError("control_data.counts must be a cells-by-genes matrix.")
     num_cells, num_genes = counts.shape
@@ -501,7 +508,7 @@ def polish_baseline_to_null_mode(
 
     from perturbo._internal.jax_kernels import fisher_nb_null
 
-    counts = np.asarray(nuisance.counts, dtype=np.float64)
+    counts = np.asarray(nuisance.counts)
     num_cells, num_genes = counts.shape
     if gene_block < 1 or max_iterations < 1:
         raise ValueError("gene_block and max_iterations must be positive.")
@@ -770,8 +777,24 @@ def build_chunk_design(
     num_control = control_counts.shape[0]
     num_chunk = chunk_counts.shape[0]
 
-    chunk_labels = np.asarray(chunk_data.pert_id)
-    if chunk_labels.ndim == 2:
+    chunk_labels = chunk_data.pert_id
+    if isinstance(chunk_labels, IndexedDesignMatrix):
+        indices = np.asarray(chunk_labels.indices, dtype=np.int64)
+        values = np.asarray(chunk_labels.values)
+        active = (indices >= 0) & (values > 0)
+        assignments = active.sum(axis=1)
+        num_multi_dropped = int(np.count_nonzero(assignments > 1))
+        if num_multi_dropped:
+            print(
+                f"[perturbo] CRT: setting aside {num_multi_dropped} of {num_chunk} chunk cells that carry "
+                "more than one perturbation; the control-anchored test needs one per cell "
+                "(--crt-pool all-cells keeps them)."
+            )
+        first = np.argmax(active, axis=1)
+        codes = np.where(assignments == 1, indices[np.arange(num_chunk), first], -1)
+        unassigned = assignments != 1
+    elif chunk_labels.ndim == 2:
+        chunk_labels = np.asarray(chunk_labels)
         assignments = np.asarray(chunk_labels > 0).sum(axis=1)
         num_multi_dropped = int(np.count_nonzero(assignments > 1))
         if num_multi_dropped:
@@ -786,6 +809,7 @@ def build_chunk_design(
         codes = np.where(assignments == 1, np.argmax(np.asarray(chunk_labels > 0), axis=1), -1)
         unassigned = assignments != 1
     elif chunk_labels.ndim == 1:
+        chunk_labels = np.asarray(chunk_labels)
         codes = chunk_labels.astype(np.int64)
         unassigned = np.zeros(num_chunk, dtype=bool)
         num_multi_dropped = 0
@@ -982,13 +1006,17 @@ def run_crt_for_chunk(
 
     # cells the control-anchored test set aside; the design builder prints it.
 
-    _labels = np.asarray(chunk_data.pert_id)
-
-    num_multi_dropped = (
-
-        int(np.count_nonzero(np.asarray(_labels > 0).sum(axis=1) > 1)) if _labels.ndim == 2 else 0
-
-    )
+    _labels = chunk_data.pert_id
+    if isinstance(_labels, IndexedDesignMatrix):
+        _active = (np.asarray(_labels.indices) >= 0) & (np.asarray(_labels.values) > 0)
+        num_multi_dropped = int(np.count_nonzero(_active.sum(axis=1) > 1))
+    else:
+        _labels = np.asarray(_labels)
+        num_multi_dropped = (
+            int(np.count_nonzero(np.asarray(_labels > 0).sum(axis=1) > 1))
+            if _labels.ndim == 2
+            else 0
+        )
 
     design = build_chunk_design(baseline, chunk_data, control_data=control_data)
     categorical_batch = design.batch_codes is not None and _categorical_batch_applies(design)
@@ -1175,14 +1203,20 @@ def _element_membership(data: PerTurboData) -> tuple[np.ndarray, np.ndarray, int
         )
     guide_to_element = np.asarray(data.guide_to_element) > 0
     num_guides, num_elements = guide_to_element.shape
-    guide_matrix = np.asarray(data.guide_matrix)
+    guide_matrix = data.guide_matrix
     num_cells = int(guide_matrix.shape[0])
     if int(guide_matrix.shape[1]) != int(num_guides):
         raise ValueError(
             f"guide_matrix has {guide_matrix.shape[1]} guides but guide_to_element maps {num_guides}."
         )
-    cells, guides = np.nonzero(guide_matrix > 0)
-    del guide_matrix
+    if isinstance(guide_matrix, IndexedDesignMatrix):
+        indices = np.asarray(guide_matrix.indices, dtype=np.int64)
+        values = np.asarray(guide_matrix.values)
+        active = (indices >= 0) & (values > 0)
+        cells = np.broadcast_to(np.arange(num_cells)[:, None], indices.shape)[active]
+        guides = indices[active]
+    else:
+        cells, guides = np.nonzero(np.asarray(guide_matrix) > 0)
     # Expand each detected (cell, guide) to the guide's elements. The map's
     # non-zeros come out sorted by guide, so a guide's elements are one
     # contiguous run starting at offsets[guide].
@@ -1205,6 +1239,110 @@ def _element_membership(data: PerTurboData) -> tuple[np.ndarray, np.ndarray, int
     return cell_index.astype(np.int64), element_index.astype(np.int64), int(num_elements)
 
 
+@dataclass(frozen=True)
+class AllCellsPropensityFit:
+    """Gene-independent state reused across gene blocks of an all-cells CRT."""
+
+    cell_index: np.ndarray
+    element_index: np.ndarray
+    element_names: tuple[str, ...]
+    testable: np.ndarray
+    coefficients: np.ndarray
+    basis: np.ndarray
+    num_cells: int
+
+
+def prepare_all_cells_propensity(
+    baseline: CRTBaseline,
+    data: PerTurboData,
+    *,
+    min_cells_per_element: int = 1,
+    include_guide_count: bool = True,
+    max_iterations: int = 25,
+    eta_clip: float = 30.0,
+    element_batch_size: int = 64,
+) -> AllCellsPropensityFit:
+    """Fit the all-cells assignment models once for reuse over gene blocks."""
+
+    from perturbo._internal.high_moi.resampling import (
+        fit_propensity_coefficients,
+        propensity_basis,
+    )
+
+    num_cells = int(np.asarray(data.counts).shape[0])
+    if baseline.num_control_cells != num_cells:
+        raise ValueError(
+            "The all-cells CRT baseline must be prepared on the analysed cells themselves "
+            f"(baseline holds {baseline.num_control_cells} cells, data holds {num_cells})."
+        )
+    cell_index, element_index, num_elements = _element_membership(data)
+    element_names = tuple(str(name) for name in data.pert_names)
+    if len(element_names) != num_elements:
+        raise ValueError(
+            f"pert_names has {len(element_names)} entries but guide_to_element maps to {num_elements} elements."
+        )
+    sizes = np.bincount(element_index, minlength=num_elements)
+    testable = sizes >= int(min_cells_per_element)
+    keep_pair = testable[element_index]
+    cell_index, element_index = cell_index[keep_pair], element_index[keep_pair]
+
+    nuisance_design = np.asarray(baseline.nuisance.nuisance_design, dtype=np.float32)
+    propensity_design = nuisance_design
+    if include_guide_count:
+        if isinstance(data.guide_matrix, IndexedDesignMatrix):
+            detected = np.sum(
+                (np.asarray(data.guide_matrix.indices) >= 0)
+                & (np.asarray(data.guide_matrix.values) > 0),
+                axis=1,
+                dtype=np.float64,
+            )
+        else:
+            detected = np.asarray(np.asarray(data.guide_matrix) > 0).sum(axis=1).astype(np.float64)
+        moi = np.log1p(detected)
+        moi = (moi - moi.mean()) / max(float(moi.std()), 1e-8)
+        propensity_design = np.concatenate(
+            [nuisance_design, moi.astype(np.float32)[:, None]], axis=1
+        )
+
+    coefficients_parts = []
+    basis = None
+    order = np.argsort(element_index, kind="stable")
+    sorted_elements = element_index[order]
+    sorted_cells = cell_index[order]
+    starts = np.searchsorted(sorted_elements, np.arange(num_elements + 1))
+    for start in range(0, num_elements, int(element_batch_size)):
+        stop = min(start + int(element_batch_size), num_elements)
+        indicators = np.zeros((stop - start, num_cells), dtype=np.float32)
+        for local, element in enumerate(range(start, stop)):
+            indicators[local, sorted_cells[starts[element] : starts[element + 1]]] = 1.0
+        coef, basis_batch = fit_propensity_coefficients(
+            indicators,
+            propensity_design,
+            max_iterations=int(max_iterations),
+            eta_clip=float(eta_clip),
+            basis=basis,
+        )
+        coefficients_parts.append(np.asarray(coef))
+        if basis is None:
+            basis = np.asarray(basis_batch)
+    if basis is None:
+        basis = np.asarray(propensity_basis(propensity_design))
+    coefficients = (
+        np.concatenate(coefficients_parts, axis=0)
+        if coefficients_parts
+        else np.zeros((0, basis.shape[1]), dtype=np.float32)
+    )
+    return AllCellsPropensityFit(
+        cell_index=cell_index,
+        element_index=element_index,
+        element_names=element_names,
+        testable=testable,
+        coefficients=coefficients,
+        basis=basis,
+        num_cells=num_cells,
+    )
+
+
 def run_crt_all_cells(
     baseline: CRTBaseline,
     data: PerTurboData,
@@ -1218,6 +1356,7 @@ def run_crt_all_cells(
     include_guide_count_in_propensity: bool = True,
     propensity_max_iterations: int = 25,
     eta_clip: float = 30.0,
+    propensity_fit: AllCellsPropensityFit | None = None,
 ) -> ChunkCRTResult:
     """The propensity saddlepoint CRT with every analysed cell as the pool (high MOI).
 
@@ -1240,7 +1379,6 @@ def run_crt_all_cells(
     the caller's, as for the chunked low-MOI path.
     """
 
-    from perturbo._internal.high_moi.resampling import fit_propensity_coefficients
     from perturbo._internal.saddlepoint import fit_high_moi_propensity_saddlepoint
 
     num_cells = int(np.asarray(data.counts).shape[0])
@@ -1254,46 +1392,26 @@ def run_crt_all_cells(
     if not 0.0 < screen_p_value <= 1.0:
         raise ValueError("screen_p_value must lie in (0, 1].")
 
-    cell_index, element_index, num_elements = _element_membership(data)
-    element_names = tuple(str(name) for name in data.pert_names)
-    if len(element_names) != num_elements:
-        raise ValueError(
-            f"pert_names has {len(element_names)} entries but guide_to_element maps to {num_elements} elements."
-        )
-    sizes = np.bincount(element_index, minlength=num_elements)
-    testable = sizes >= int(min_cells_per_element)
-    keep_pair = testable[element_index]
-    cell_index, element_index = cell_index[keep_pair], element_index[keep_pair]
-
     nuisance_design = np.asarray(baseline.nuisance.nuisance_design, dtype=np.float32)
-    propensity_design = nuisance_design
-    if include_guide_count_in_propensity:
-        detected = np.asarray(np.asarray(data.guide_matrix) > 0).sum(axis=1).astype(np.float64)
-        moi = np.log1p(detected)
-        moi = (moi - moi.mean()) / max(float(moi.std()), 1e-8)
-        propensity_design = np.concatenate([nuisance_design, moi.astype(np.float32)[:, None]], axis=1)
-
-    # Per-element selection models, in batches so the dense indicator block
-    # stays (batch, cells). The basis is the same QR of one design for every
-    # batch, so it is taken from the first.
-    coefficients_parts = []
-    basis = None
-    order = np.argsort(element_index, kind="stable")
-    sorted_elements = element_index[order]
-    sorted_cells = cell_index[order]
-    starts = np.searchsorted(sorted_elements, np.arange(num_elements + 1))
-    for start in range(0, num_elements, int(element_batch_size)):
-        stop = min(start + int(element_batch_size), num_elements)
-        indicators = np.zeros((stop - start, num_cells), dtype=np.float32)
-        for local, element in enumerate(range(start, stop)):
-            indicators[local, sorted_cells[starts[element] : starts[element + 1]]] = 1.0
-        coef, basis_batch = fit_propensity_coefficients(
-            indicators, propensity_design, max_iterations=int(propensity_max_iterations), eta_clip=float(eta_clip)
+    if propensity_fit is None:
+        propensity_fit = prepare_all_cells_propensity(
+            baseline,
+            data,
+            min_cells_per_element=int(min_cells_per_element),
+            include_guide_count=bool(include_guide_count_in_propensity),
+            max_iterations=int(propensity_max_iterations),
+            eta_clip=float(eta_clip),
+            element_batch_size=int(element_batch_size),
         )
-        coefficients_parts.append(np.asarray(coef))
-        if basis is None:
-            basis = np.asarray(basis_batch)
-    coefficients = np.concatenate(coefficients_parts, axis=0) if coefficients_parts else np.zeros((0, propensity_design.shape[1]))
+    element_names = tuple(str(name) for name in data.pert_names)
+    if propensity_fit.num_cells != num_cells or propensity_fit.element_names != element_names:
+        raise ValueError("propensity_fit does not match the all-cells CRT data.")
+    cell_index = propensity_fit.cell_index
+    element_index = propensity_fit.element_index
+    testable = propensity_fit.testable
+    coefficients = propensity_fit.coefficients
+    basis = propensity_fit.basis
+    num_elements = len(element_names)
 
     num_genes = baseline.num_genes
     width = num_genes if gene_chunk_size is None else int(gene_chunk_size)
@@ -1392,12 +1510,38 @@ def exclude_targets(chunk_data: PerTurboData, drop_names: Iterable[str]) -> PerT
     if keep_targets.all():
         return chunk_data
 
-    labels = np.asarray(chunk_data.pert_id)
+    labels = chunk_data.pert_id
     old_to_new = np.full(len(names), -1, dtype=np.int64)
     old_to_new[np.flatnonzero(keep_targets)] = np.arange(int(keep_targets.sum()))
-    if labels.ndim == 1:
-        keep_cells = keep_targets[labels.astype(np.int64)]
-        new_labels = old_to_new[labels.astype(np.int64)[keep_cells]]
+    if isinstance(labels, IndexedDesignMatrix):
+        indices = np.asarray(labels.indices, dtype=np.int64)
+        values = np.asarray(labels.values)
+        safe = np.maximum(indices, 0)
+        mapped = old_to_new[safe]
+        active = (indices >= 0) & (values != 0) & (mapped >= 0)
+        keep_cells = active.any(axis=1)
+        kept_active = active[keep_cells]
+        kept_mapped = mapped[keep_cells]
+        kept_values = values[keep_cells]
+        widths = kept_active.sum(axis=1)
+        width = max(1, int(widths.max(initial=0)))
+        new_indices = np.full((int(keep_cells.sum()), width), -1, dtype=np.int32)
+        new_values = np.zeros((int(keep_cells.sum()), width), dtype=np.float32)
+        for row in range(new_indices.shape[0]):
+            row_active = kept_active[row]
+            count = int(row_active.sum())
+            if count:
+                new_indices[row, :count] = kept_mapped[row, row_active]
+                new_values[row, :count] = kept_values[row, row_active]
+        new_labels = IndexedDesignMatrix(
+            indices=jnp.asarray(new_indices),
+            values=jnp.asarray(new_values),
+            num_columns=int(keep_targets.sum()),
+        )
+    elif labels.ndim == 1:
+        labels_array = np.asarray(labels)
+        keep_cells = keep_targets[labels_array.astype(np.int64)]
+        new_labels = old_to_new[labels_array.astype(np.int64)[keep_cells]]
     elif labels.ndim == 2:
         binary = np.asarray(labels > 0)
         keep_cells = binary[:, keep_targets].any(axis=1)
@@ -1408,17 +1552,24 @@ def exclude_targets(chunk_data: PerTurboData, drop_names: Iterable[str]) -> PerT
         return None
 
     def _rows(values):
-        return None if values is None else jnp.asarray(np.asarray(values)[keep_cells])
+        if values is None:
+            return None
+        if isinstance(values, IndexedDesignMatrix):
+            return values.take_rows(keep_cells)
+        return jnp.asarray(np.asarray(values)[keep_cells])
 
     return PerTurboData(
         counts=jnp.asarray(np.asarray(chunk_data.counts)[keep_cells]),
-        pert_id=jnp.asarray(new_labels),
+        pert_id=(new_labels if isinstance(new_labels, IndexedDesignMatrix) else jnp.asarray(new_labels)),
         pert_names=[name for name, keep in zip(names, keep_targets, strict=True) if keep],
         gene_names=list(chunk_data.gene_names),
         cell_mask=_rows(chunk_data.cell_mask),
         size_factors=_rows(chunk_data.size_factors),
         covariates=_rows(chunk_data.covariates),
         covariate_names=None if chunk_data.covariate_names is None else list(chunk_data.covariate_names),
+        guide_matrix=_rows(chunk_data.guide_matrix),
+        guide_names=None if chunk_data.guide_names is None else list(chunk_data.guide_names),
+        guide_to_element=chunk_data.guide_to_element,
         library_size_center_log_mean=chunk_data.library_size_center_log_mean,
     )
 
@@ -1444,6 +1595,8 @@ class CRTAccumulator:
     def __post_init__(self) -> None:
         shape = (len(self.element_names), len(self.gene_names))
         self._index = {name: position for position, name in enumerate(self.element_names)}
+        self._gene_index = {name: position for position, name in enumerate(self.gene_names)}
+        self._dropped_by_target_chunk: dict[tuple[str, ...], int] = {}
         self.num_multi_assignment_cells_dropped = 0
         self.observed_score = np.full(shape, np.nan, dtype=np.float64)
         self.p_value = np.full(shape, np.nan, dtype=np.float64)
@@ -1462,26 +1615,36 @@ class CRTAccumulator:
         }
 
     def absorb(self, result: ChunkCRTResult) -> None:
-        if tuple(result.gene_names) != self.gene_names:
-            raise ValueError("Chunk gene names do not match the accumulator's gene axis.")
         unknown = [name for name in result.target_names if name not in self._index]
         if unknown:
             raise ValueError(f"Chunk reported elements absent from the screen: {unknown[:5]}")
+        unknown_genes = [name for name in result.gene_names if name not in self._gene_index]
+        if unknown_genes:
+            raise ValueError(
+                f"Chunk gene names do not match the accumulator: absent from the screen {unknown_genes[:5]}"
+            )
         rows = np.asarray([self._index[name] for name in result.target_names])
-        self.num_multi_assignment_cells_dropped += int(getattr(result, "num_multi_assignment_cells_dropped", 0))
-        self.observed_score[rows] = result.observed_score
-        self.p_value[rows] = result.p_value
-        self.null_converged[rows] = result.null_converged
+        columns = np.asarray([self._gene_index[name] for name in result.gene_names])
+        destination = np.ix_(rows, columns)
+        target_chunk = tuple(result.target_names)
+        self._dropped_by_target_chunk[target_chunk] = max(
+            self._dropped_by_target_chunk.get(target_chunk, 0),
+            int(getattr(result, "num_multi_assignment_cells_dropped", 0)),
+        )
+        self.num_multi_assignment_cells_dropped = sum(self._dropped_by_target_chunk.values())
+        self.observed_score[destination] = result.observed_score
+        self.p_value[destination] = result.p_value
+        self.null_converged[destination] = result.null_converged
         self.tested[rows] = True
         for family, columns in result.parametric.items():
             if family not in self.parametric:
                 continue
             for key, values in columns.items():
                 if key in self.parametric[family]:
-                    self.parametric[family][key][rows] = values
+                    self.parametric[family][key][destination] = values
         for name, values in result.null_summaries.items():
             if name in self.null_summaries:
-                self.null_summaries[name][rows] = values
+                self.null_summaries[name][destination] = values
 
     def finalize(self) -> dict[str, np.ndarray]:
         """Screen-wide columns, with Benjamini-Hochberg over every tested pair.

--- a/src/perturbo/io.py
+++ b/src/perturbo/io.py
@@ -20,6 +20,7 @@ _SETUP_UNS_KEY = "_perturbo_setup"
 # Bundles written by the Cortado prototype carry the old key. They are read and
 # upgraded in memory rather than refused, so existing MuData files keep working.
 _LEGACY_SETUP_UNS_KEY = "_cortado_setup"
+_SAVED_SIZE_FACTOR_KEY = "_perturbo_saved_size_factor"
 
 
 @dataclass
@@ -37,6 +38,8 @@ class MuDataSetup:
     guide_element_uns_key: str | None = None
     gene_name_key: str | None = None
     control_substring: str | None = None
+    size_factor_mode: str | None = None
+    size_factor_provenance: str | None = None
 
     def to_json_dict(self) -> dict[str, Any]:
         payload = asdict(self)
@@ -127,6 +130,8 @@ def setup_mudata(
     control_substring: str | None = None,
     modalities: dict[str, str] | None = None,
     perturbation_layer: str | None = None,
+    size_factor_mode: str | None = None,
+    size_factor_provenance: str | None = None,
 ) -> MuDataSetup:
     """Register MuData metadata for perturbo workflows.
 
@@ -168,6 +173,8 @@ def setup_mudata(
         guide_element_uns_key=guide_element_uns_key,
         gene_name_key=gene_name_key,
         control_substring=control_substring,
+        size_factor_mode=size_factor_mode,
+        size_factor_provenance=size_factor_provenance,
     )
     if setup.control_substring is None:
         setup.control_substring = _infer_control_substring(
@@ -297,6 +304,7 @@ def save_light_fit_bundle(
     beta_arrays: dict[str, Any],
     guide_posteriors: dict[str, Any] | None = None,
     guide_efficacy: np.ndarray | None = None,
+    size_factors: np.ndarray | None = None,
     cell_keep_indices: np.ndarray | None = None,
 ) -> Path:
     bundle_dir = Path(out_dir)
@@ -309,6 +317,10 @@ def save_light_fit_bundle(
         keep = np.asarray(cell_keep_indices, dtype=np.int64).reshape(-1)
         np.save(bundle_dir / "cell_keep_indices.npy", keep)
         payload["cell_keep_indices_file"] = "cell_keep_indices.npy"
+    if size_factors is not None:
+        values = np.asarray(size_factors, dtype=np.float32).reshape(-1, 1)
+        np.save(bundle_dir / "size_factors.npy", values)
+        payload["size_factors_file"] = "size_factors.npy"
     write_json(bundle_dir / "metadata.json", payload)
     save_array_bundle(bundle_dir / "control_fit.npz", control_arrays)
     save_array_bundle(bundle_dir / "beta_fit.npz", beta_arrays)
@@ -440,9 +452,35 @@ def _load_light_bundle_mdata(root: Path, metadata: dict[str, Any], source_data: 
     source = _subset_source_by_obs_indices(source, setup, _read_cell_keep_indices(root, metadata))
     if setup.perturbation_modality in getattr(source, "mod", {}):
         mdata = source
-        mdata.uns[_SETUP_UNS_KEY] = setup.to_json_dict()
     else:
         mdata = _low_moi_source_to_mudata(source, metadata, setup)
+
+    size_factors_file = metadata.get("size_factors_file")
+    if size_factors_file is not None:
+        values_path = root / str(size_factors_file)
+        if not values_path.exists():
+            raise FileNotFoundError(f"Light fit bundle references missing size-factor file: {values_path}")
+        values = np.asarray(np.load(values_path), dtype=np.float32).reshape(-1)
+        rna = mdata[setup.rna_modality]
+        if values.shape[0] != rna.n_obs:
+            raise ValueError(
+                "Saved size-factor row count does not match the light bundle source data: "
+                f"{values.shape[0]} != {rna.n_obs}."
+            )
+        if not np.all(np.isfinite(values)):
+            raise ValueError("Saved size factors must contain only finite values.")
+        obs = rna.obs.copy()
+        obs[_SAVED_SIZE_FACTOR_KEY] = values
+        rna.obs = obs
+        setup.size_factor_key = _SAVED_SIZE_FACTOR_KEY
+        setup.library_size_key = None
+    if setup.size_factor_mode is None:
+        raw_mode = metadata.get("size_factor_mode")
+        setup.size_factor_mode = None if raw_mode is None else str(raw_mode)
+    if setup.size_factor_provenance is None:
+        raw_provenance = metadata.get("size_factor_provenance")
+        setup.size_factor_provenance = None if raw_provenance is None else str(raw_provenance)
+    mdata.uns[_SETUP_UNS_KEY] = setup.to_json_dict()
 
     expected_genes = metadata.get("gene_names")
     if expected_genes is not None:

--- a/src/perturbo/log_normal_negative_binomial.py
+++ b/src/perturbo/log_normal_negative_binomial.py
@@ -15,7 +15,7 @@ from numpyro.distributions.util import promote_shapes, validate_sample
 def _get_quad_rule(num_quad_points: int, dtype) -> tuple[jnp.ndarray, jnp.ndarray]:
     quad_rule = hermegauss(num_quad_points)
     points = jnp.asarray(quad_rule[0], dtype=dtype)
-    log_weights = jnp.asarray(quad_rule[1], dtype=dtype)
+    log_weights = jnp.log(jnp.asarray(quad_rule[1], dtype=dtype))
     log_weights = log_weights - logsumexp(log_weights)
     return points, log_weights
 
@@ -95,7 +95,8 @@ class LogNormalNegativeBinomial(Distribution):
             total_count=self.total_count,
             logits=self.logits + normals,
         )
-        return nb_dist.sample(nb_key, sample_shape=sample_shape)
+        # The normal draw already expanded the NB batch by sample_shape.
+        return nb_dist.sample(nb_key)
 
     def expand(self, batch_shape):
         batch_shape = tuple(batch_shape)

--- a/src/perturbo/model.py
+++ b/src/perturbo/model.py
@@ -7,6 +7,7 @@ import numpyro.distributions as dist
 
 from perturbo.log_normal_negative_binomial import LogNormalNegativeBinomial
 import perturbo.plate  # noqa: F401  installs the subsample-aware plate as numpyro.plate
+from perturbo.sparse_design import IndexedDesignMatrix, design_matrix_product
 
 
 def create_plates(
@@ -86,6 +87,26 @@ def _subsample_cell_axis(
         return values
     if num_cells is not None and values.shape[0] == num_cells:
         return values[sampled_cell_idx, ...]
+    raise ValueError(
+        f"{name} has incompatible shape {values.shape}; expected leading axis {batch_size} "
+        f"(already subsampled) or {num_cells} (full dataset)."
+    )
+
+
+def _subsample_design_rows(
+    values,
+    sampled_cell_idx: jnp.ndarray,
+    *,
+    num_cells: int | None,
+    name: str,
+):
+    if not isinstance(values, IndexedDesignMatrix):
+        return _subsample_cell_axis(values, sampled_cell_idx, num_cells=num_cells, name=name)
+    batch_size = int(sampled_cell_idx.shape[0])
+    if values.shape[0] == batch_size:
+        return values
+    if num_cells is not None and values.shape[0] == num_cells:
+        return values.take_rows(sampled_cell_idx)
     raise ValueError(
         f"{name} has incompatible shape {values.shape}; expected leading axis {batch_size} "
         f"(already subsampled) or {num_cells} (full dataset)."
@@ -268,7 +289,7 @@ def BaseModel(
 
     with cell_plate as sampled_cell_idx:
         counts = _subsample_cell_axis(counts, sampled_cell_idx, num_cells=full_num_cells, name="counts")
-        pert_id = _subsample_cell_axis(pert_id, sampled_cell_idx, num_cells=full_num_cells, name="pert_id")
+        pert_id = _subsample_design_rows(pert_id, sampled_cell_idx, num_cells=full_num_cells, name="pert_id")
         size_factor_obs = _subsample_cell_axis(
             size_factors,
             sampled_cell_idx,
@@ -281,7 +302,7 @@ def BaseModel(
             num_cells=full_num_cells,
             name="covariates",
         )
-        guide_matrix = _subsample_cell_axis(
+        guide_matrix = _subsample_design_rows(
             guide_matrix,
             sampled_cell_idx,
             num_cells=full_num_cells,
@@ -317,11 +338,11 @@ def BaseModel(
                         jnp.reciprocal(theta)[None, :] + dispersion_excess_inverse[pert_id, :]
                     )
             elif pert_id.ndim == 2:
-                pert_matrix = jnp.asarray(pert_id, dtype=beta.dtype)
-                pert_effect = pert_matrix @ beta
+                pert_effect = design_matrix_product(pert_id, beta)
                 if fit_perturbation_dispersion:
                     effective_theta = jnp.reciprocal(
-                        jnp.reciprocal(theta)[None, :] + pert_matrix @ dispersion_excess_inverse
+                        jnp.reciprocal(theta)[None, :]
+                        + design_matrix_product(pert_id, dispersion_excess_inverse)
                     )
             else:
                 raise ValueError("pert_id must be 1D (indices) or 2D (binary matrix).")
@@ -339,7 +360,7 @@ def BaseModel(
                 mu = mu + factor_contrib
                 mu_outlier = mu_outlier + factor_contrib
             if guide_random_effect is not None and guide_matrix is not None:
-                guide_random_effect_contrib = jnp.asarray(guide_matrix, dtype=guide_random_effect.dtype) @ guide_random_effect
+                guide_random_effect_contrib = design_matrix_product(guide_matrix, guide_random_effect)
                 mu = mu + guide_random_effect_contrib
                 mu_outlier = mu_outlier + guide_random_effect_contrib
 
@@ -494,7 +515,13 @@ def GuideSharedEffectModel(
 
     with cell_plate as sampled_cell_idx:
         counts = _subsample_cell_axis(counts, sampled_cell_idx, num_cells=full_num_cells, name="counts")
-        guide_matrix = _subsample_cell_axis(
+        pert_id = _subsample_design_rows(
+            pert_id,
+            sampled_cell_idx,
+            num_cells=full_num_cells,
+            name="pert_id",
+        )
+        guide_matrix = _subsample_design_rows(
             guide_matrix,
             sampled_cell_idx,
             num_cells=full_num_cells,
@@ -530,11 +557,17 @@ def GuideSharedEffectModel(
                 with factor_plate:
                     factor_scores = numpyro.sample("factor_scores", dist.Normal(0, 1.0))
 
-            guide_effect_matrix = jnp.asarray(guide_matrix, dtype=guide_effect.dtype) @ guide_effect
+            # Shared guide effects are element effects. Use the binary grouped
+            # element design so two guides aimed at the same element do not
+            # duplicate that element's mean contribution.
+            if guide_effect_strategy == "shared":
+                guide_effect_matrix = design_matrix_product(pert_id, beta)
+            else:
+                guide_effect_matrix = design_matrix_product(guide_matrix, guide_effect)
             if fit_perturbation_dispersion:
                 effective_theta = jnp.reciprocal(
                     jnp.reciprocal(theta)[None, :]
-                    + jnp.asarray(guide_matrix, dtype=theta.dtype) @ guide_dispersion_excess_inverse
+                    + design_matrix_product(guide_matrix, guide_dispersion_excess_inverse)
                 )
             mu = beta_0 + guide_effect_matrix + size_factor
             # Outlier component is a right-shifted baseline mode and does not
@@ -549,7 +582,7 @@ def GuideSharedEffectModel(
                 mu = mu + factor_contrib
                 mu_outlier = mu_outlier + factor_contrib
             if guide_random_effect is not None:
-                guide_random_effect_contrib = jnp.asarray(guide_matrix, dtype=guide_random_effect.dtype) @ guide_random_effect
+                guide_random_effect_contrib = design_matrix_product(guide_matrix, guide_random_effect)
                 mu = mu + guide_random_effect_contrib
                 mu_outlier = mu_outlier + guide_random_effect_contrib
 

--- a/src/perturbo/simulation/fitted.py
+++ b/src/perturbo/simulation/fitted.py
@@ -15,7 +15,7 @@ import pandas as pd
 
 from perturbo import core
 from perturbo.inference import PerTurboModel
-from perturbo.io import setup_mudata
+from perturbo.io import _SAVED_SIZE_FACTOR_KEY, setup_mudata
 from perturbo.log_normal_negative_binomial import LogNormalNegativeBinomial
 
 
@@ -37,13 +37,15 @@ def _resolve_gene_indices(model: PerTurboModel, gene_indices: np.ndarray | None)
 
 def _resolve_size_factors(model: PerTurboModel, cell_indices: np.ndarray, read_depth_adjust_factor: float) -> np.ndarray:
     obs = model.adata[model.setup.rna_modality].obs.iloc[cell_indices]
-    if model.setup.size_factor_key is not None and model.setup.size_factor_key in obs.columns:
+    if getattr(model.setup, "size_factor_mode", None) == "none":
+        size_factor = np.zeros((cell_indices.shape[0], 1), dtype=np.float32)
+    elif model.setup.size_factor_key is not None and model.setup.size_factor_key in obs.columns:
         size_factor_raw = pd.to_numeric(obs[model.setup.size_factor_key], errors="coerce").to_numpy(dtype=np.float32)
         if not np.all(np.isfinite(size_factor_raw)):
             raise ValueError(
                 f"size_factor_key '{model.setup.size_factor_key}' contains non-finite values in simulated source cells."
             )
-        if core._is_count_like(size_factor_raw):
+        if model.setup.size_factor_key != _SAVED_SIZE_FACTOR_KEY and core._is_count_like(size_factor_raw):
             raise ValueError(
                 f"size_factor_key '{model.setup.size_factor_key}' appears to contain integer counts. "
                 "Use library_size_key for count data, or provide real-valued size factors centered around zero."
@@ -82,6 +84,7 @@ def _sample_counts(
     *,
     model: PerTurboModel,
     mu: np.ndarray,
+    outlier_mu: np.ndarray | None = None,
     gene_indices: np.ndarray,
     theta_override: np.ndarray | None = None,
     seed: int = 0,
@@ -101,10 +104,10 @@ def _sample_counts(
         for index, start in enumerate(range(0, n_cells, chunk_rows)):
             stop = min(start + chunk_rows, n_cells)
             override = None if theta_override is None else np.asarray(theta_override)[start:stop]
+            outlier_mu_part = None if outlier_mu is None else np.asarray(outlier_mu)[start:stop]
             parts.append(
                 _sample_counts(
-                    model=model,
-                    mu=np.asarray(mu)[start:stop],
+                    model=model, mu=np.asarray(mu)[start:stop], outlier_mu=outlier_mu_part,
                     gene_indices=gene_indices,
                     theta_override=override,
                     seed=int(jax.random.key_data(jax.random.fold_in(jax.random.PRNGKey(seed), index))[-1]),
@@ -141,8 +144,9 @@ def _sample_counts(
             if control_fit.outlier_mean_shift is not None
             else np.zeros_like(theta_outlier)
         )
+        outlier_predictor = mu if outlier_mu is None else np.asarray(outlier_mu)
         logits_outlier = jnp.asarray(
-            mu + outlier_shift[None, :] - np.log(theta_outlier)[None, :],
+            outlier_predictor + outlier_shift[None, :] - np.log(theta_outlier)[None, :],
             dtype=jnp.float32,
         )
         component_distribution = dist.NegativeBinomialLogits(
@@ -281,9 +285,20 @@ def simulate_data_from_trained_model(
     gene_idx = _resolve_gene_indices(model, gene_indices)
     cell_idx = _resolve_cell_indices(model, guide_obs_arr.shape[0], cell_indices)
     lfc = np.asarray(element_by_gene_lfc, dtype=np.float32)[:, gene_idx]
-    weighted_guides = guide_obs_arr * guide_eff_arr[None, :]
-    element_scores = weighted_guides @ guide_by_element_arr
     element_membership = guide_obs_arr @ guide_by_element_arr
+    weighted_guides = guide_obs_arr * guide_eff_arr[None, :]
+    # The fitted shared-effect design records whether an element is present,
+    # so two observed guides for the same element still contribute one beta.
+    # Unit efficacy is the saved/default shared strategy. A caller-provided
+    # non-unit vector remains an explicit guide weighting override.
+    shared_unit_efficacy = (
+        str(getattr(model, "guide_effect_strategy", "shared")).lower() == "shared"
+        and np.allclose(guide_eff_arr, 1.0, rtol=0.0, atol=1e-6)
+    )
+    if shared_unit_efficacy:
+        element_scores = np.asarray(element_membership > 0, dtype=np.float32)
+    else:
+        element_scores = weighted_guides @ guide_by_element_arr
 
     beta_0 = np.asarray(model.control_fit.beta_0, dtype=np.float32)[gene_idx]
     mu = beta_0[None, :] + _resolve_size_factors(model, cell_idx, read_depth_adjust_factor)
@@ -291,6 +306,7 @@ def simulate_data_from_trained_model(
     if covariates is not None and model.control_fit.covariate_coef is not None:
         cov_coef = np.asarray(model.control_fit.covariate_coef, dtype=np.float32)[:, gene_idx]
         mu = mu + covariates @ cov_coef
+    outlier_mu = np.asarray(mu).copy()
     mu = mu + element_scores @ lfc
     guide_random_effect_contrib = _sample_guide_random_effect_contribution(
         model=model,
@@ -300,6 +316,7 @@ def simulate_data_from_trained_model(
     )
     if guide_random_effect_contrib is not None:
         mu = mu + guide_random_effect_contrib
+        outlier_mu = outlier_mu + guide_random_effect_contrib
 
     theta_override = _resolve_perturbation_dispersion_theta(
         model=model,
@@ -308,7 +325,12 @@ def simulate_data_from_trained_model(
         gene_indices=gene_idx,
     )
     counts = _sample_counts(
-        model=model, mu=mu, gene_indices=gene_idx, theta_override=theta_override, seed=int(seed)
+        model=model,
+        mu=mu,
+        outlier_mu=outlier_mu,
+        gene_indices=gene_idx,
+        theta_override=theta_override,
+        seed=int(seed),
     )
 
     rna_source = model.adata[model.setup.rna_modality]
@@ -360,6 +382,8 @@ def simulate_data_from_trained_model(
             "perturbation_layer": model.setup.perturbation_modality,
         },
         perturbation_layer=model.setup.perturbation_layer,
+        size_factor_mode=model.setup.size_factor_mode,
+        size_factor_provenance=model.setup.size_factor_provenance,
     )
     return mdata
 

--- a/src/perturbo/sparse_design.py
+++ b/src/perturbo/sparse_design.py
@@ -1,0 +1,103 @@
+"""Compact row-indexed design matrices for sparse perturbation assignments."""
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+import jax.numpy as jnp
+import numpy as np
+import scipy.sparse as sp
+
+
+class IndexedDesignMatrix(NamedTuple):
+    """A fixed-width list of active columns for every design row.
+
+    ``indices`` and ``values`` have shape ``(num_rows, max_active)``. An index of
+    ``-1`` is padding and contributes zero. This representation is a JAX pytree,
+    can be cell-minibatched with ordinary gathers, and stores high-MOI designs in
+    memory proportional to observed assignments rather than rows times columns.
+    """
+
+    indices: jnp.ndarray
+    values: jnp.ndarray
+    num_columns: int
+
+    @property
+    def shape(self) -> tuple[int, int]:
+        return self.indices.shape[0], self.num_columns
+
+    @property
+    def ndim(self) -> int:
+        return 2
+
+    def take_rows(self, row_indices) -> IndexedDesignMatrix:
+        return IndexedDesignMatrix(
+            indices=self.indices[row_indices],
+            values=self.values[row_indices],
+            num_columns=self.num_columns,
+        )
+
+
+def indexed_design_from_matrix(matrix) -> IndexedDesignMatrix:
+    """Convert a dense or scipy sparse matrix to padded active-column rows."""
+    if sp.issparse(matrix) or hasattr(matrix, "tocsr"):
+        csr = matrix.tocsr(copy=True)
+        csr.eliminate_zeros()
+        num_rows, num_columns = csr.shape
+        row_widths = np.diff(csr.indptr)
+        max_active = max(1, int(row_widths.max(initial=0)))
+        indices = np.full((num_rows, max_active), -1, dtype=np.int32)
+        values = np.zeros((num_rows, max_active), dtype=np.float32)
+        if csr.nnz:
+            rows = np.repeat(np.arange(num_rows, dtype=np.int64), row_widths)
+            slots = np.arange(csr.nnz, dtype=np.int64) - np.repeat(csr.indptr[:-1], row_widths)
+            indices[rows, slots] = csr.indices
+            values[rows, slots] = csr.data
+    else:
+        dense = np.asarray(matrix)
+        if dense.ndim != 2:
+            raise ValueError("An indexed design source must be a 2D matrix.")
+        num_rows, num_columns = dense.shape
+        active = dense != 0
+        row_widths = active.sum(axis=1)
+        max_active = max(1, int(row_widths.max(initial=0)))
+        indices = np.full((num_rows, max_active), -1, dtype=np.int32)
+        values = np.zeros((num_rows, max_active), dtype=np.float32)
+        rows, columns = np.nonzero(active)
+        if rows.size:
+            row_starts = np.repeat(np.cumsum(row_widths) - row_widths, row_widths)
+            slots = np.arange(rows.size, dtype=np.int64) - row_starts
+            indices[rows, slots] = columns
+            values[rows, slots] = dense[rows, columns]
+    return IndexedDesignMatrix(
+        indices=jnp.asarray(indices, dtype=jnp.int32),
+        values=jnp.asarray(values, dtype=jnp.float32),
+        num_columns=int(num_columns),
+    )
+
+
+def indexed_design_to_dense(design: IndexedDesignMatrix) -> jnp.ndarray:
+    """Materialize an indexed design, primarily for validation and tests."""
+    safe_indices = jnp.maximum(design.indices, 0)
+    mask = design.indices >= 0
+    rows = jnp.arange(design.indices.shape[0], dtype=jnp.int32)[:, None]
+    dense = jnp.zeros(design.shape, dtype=design.values.dtype)
+    return dense.at[rows, safe_indices].add(jnp.where(mask, design.values, 0))
+
+
+def design_matrix_product(design, coefficients: jnp.ndarray) -> jnp.ndarray:
+    """Return ``design @ coefficients`` without densifying an indexed design."""
+    if not isinstance(design, IndexedDesignMatrix):
+        return jnp.asarray(design, dtype=coefficients.dtype) @ coefficients
+    safe_indices = jnp.maximum(design.indices, 0)
+    gathered = coefficients[safe_indices]
+    weights = jnp.where(design.indices >= 0, design.values, 0).astype(coefficients.dtype)
+    return jnp.sum(gathered * weights[..., None], axis=1)
+
+
+def design_values_are_finite_nonnegative(design) -> bool:
+    if isinstance(design, IndexedDesignMatrix):
+        values = np.asarray(design.values)
+    else:
+        values = np.asarray(design)
+    return bool(np.all(np.isfinite(values)) and np.all(values >= 0))

--- a/tests/test_crt_cli.py
+++ b/tests/test_crt_cli.py
@@ -96,6 +96,21 @@ def test_the_accumulator_rejects_a_mismatched_gene_axis() -> None:
         accumulator.absorb(_chunk_result(("a",), ("other",), 0.5))
 
 
+def test_the_accumulator_places_gene_blocks_by_name_before_global_bh() -> None:
+    accumulator = CRTAccumulator(
+        element_names=("a", "b"), gene_names=("g0", "g1", "g2"), tail_families=()
+    )
+    accumulator.absorb(_chunk_result(("a", "b"), ("g2",), [[0.9], [0.002]]))
+    accumulator.absorb(_chunk_result(("a", "b"), ("g0", "g1"), [[0.001, 0.9], [0.9, 0.9]]))
+
+    columns = accumulator.finalize()
+    np.testing.assert_allclose(accumulator.p_value[0], [0.001, 0.9, 0.9])
+    np.testing.assert_allclose(accumulator.p_value[1], [0.9, 0.9, 0.002])
+    # Six hypotheses are corrected together after both gene blocks arrive.
+    assert columns["crt_q_value"][0, 0] == pytest.approx(0.006)
+    assert columns["crt_q_value"][1, 2] == pytest.approx(0.006)
+
+
 def test_benjamini_hochberg_spans_every_chunk() -> None:
     """The correction must see the whole family, not one chunk at a time.
 

--- a/tests/test_crt_config.py
+++ b/tests/test_crt_config.py
@@ -7,7 +7,7 @@ import numpy as np
 import pytest
 
 from perturbo.core import ControlFit, PerTurboData
-from perturbo._internal.score_resampling import fit_batched_nb_null
+from perturbo._internal.score_resampling import fit_batched_nb_null, newton_step_magnitude
 from perturbo.crt import (
     assemble_control_nuisance,
     check_baseline_is_null_mode,
@@ -188,6 +188,46 @@ def test_nuisance_assembly_without_covariates_is_intercept_only() -> None:
     nuisance = assemble_control_nuisance(data, _control_fit(beta_0, theta, None))
     assert nuisance.nuisance_design.shape == (400, 1)
     assert nuisance.nuisance_names == ("intercept",)
+
+
+def test_nuisance_assembly_keeps_the_count_panels_compact_dtype() -> None:
+    data, beta_0, theta, _ = _simulate_controls()
+    nuisance = assemble_control_nuisance(data, _control_fit(beta_0, theta, None))
+    assert nuisance.counts.dtype == np.float32
+
+
+def test_gene_blocked_newton_step_matches_the_full_panel_formula() -> None:
+    """Exercise more genes than one block and compare the original algebra."""
+
+    rng = np.random.default_rng(22)
+    cells, genes = 18, 300
+    design = np.column_stack([np.ones(cells), rng.normal(size=cells)])
+    beta = rng.normal(scale=0.15, size=(2, genes))
+    offsets = rng.normal(scale=0.1, size=(cells, 1))
+    theta = rng.uniform(2.0, 9.0, size=genes)
+    mean = np.exp(offsets + design @ beta)
+    counts = rng.poisson(mean).astype(np.float32)
+    ridge = 1e-8 * np.eye(2)
+
+    actual = newton_step_magnitude(
+        counts,
+        design,
+        offsets,
+        theta,
+        beta,
+        prior_precision=0.0,
+        ridge=ridge,
+    )
+
+    denominator = theta[None, :] + mean
+    residual = theta[None, :] * (counts - mean) / denominator
+    weight = theta[None, :] * mean / denominator
+    gradient = design.T @ residual
+    expected = np.empty(genes)
+    for gene in range(genes):
+        information = design.T @ (design * weight[:, gene, None]) + ridge
+        expected[gene] = np.max(np.abs(np.linalg.solve(information, gradient[:, gene])))
+    np.testing.assert_allclose(actual, expected, rtol=1e-12, atol=1e-12)
 
 
 def test_nuisance_assembly_rejects_covariates_without_coefficients() -> None:

--- a/tests/test_crt_element_design_low_moi.py
+++ b/tests/test_crt_element_design_low_moi.py
@@ -172,8 +172,9 @@ def test_element_grouping_is_a_fast_sparse_product():
     guide_of_cell = rng.integers(0, n_guides, n_cells)
     assignment = sp.csr_matrix((np.ones(n_cells), (np.arange(n_cells), guide_of_cell)), shape=(n_cells, n_guides))
     mapping = np.zeros((n_guides, n_elements)); mapping[np.arange(n_guides), rng.integers(0, n_elements, n_guides)] = 1
-    expected = (np.asarray(assignment.todense()) > 0).astype(np.int8) @ (mapping > 0).astype(np.int8)
-    expected = (expected > 0).astype(np.int8)
+    # Each fixture cell has exactly one known guide. A direct lookup is an
+    # independent reference without repeating the slow dense product in the test.
+    expected = (mapping[guide_of_cell] > 0).astype(np.int8)
     for matrix in (assignment, assignment.toarray().astype(np.int64)):
         start = time.perf_counter()
         got = _group_perturbation_matrix_by_element(matrix, mapping)

--- a/tests/test_crt_indexed_design.py
+++ b/tests/test_crt_indexed_design.py
@@ -1,0 +1,58 @@
+"""CRT adapters keep sparse perturbation assignments indexed."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import numpy as np
+
+from perturbo.core import PerTurboData
+from perturbo.crt import _element_membership, exclude_targets
+from perturbo.sparse_design import (
+    IndexedDesignMatrix,
+    indexed_design_from_matrix,
+    indexed_design_to_dense,
+)
+
+
+def test_all_cells_membership_reads_indexed_guides_without_densifying() -> None:
+    guides = np.asarray(
+        [[1, 0, 1], [0, 1, 0], [0, 0, 0], [1, 1, 0]], dtype=np.float32
+    )
+    guide_to_element = jnp.asarray([[1, 0], [0, 1], [1, 0]], dtype=jnp.float32)
+
+    def data(guide_matrix):
+        return PerTurboData(
+            counts=jnp.ones((4, 1), dtype=jnp.float32),
+            pert_id=indexed_design_from_matrix(guides @ np.asarray(guide_to_element)),
+            pert_names=["a", "b"],
+            gene_names=["g"],
+            guide_matrix=guide_matrix,
+            guide_names=["u", "v", "w"],
+            guide_to_element=guide_to_element,
+        )
+
+    dense = _element_membership(data(jnp.asarray(guides)))
+    indexed = _element_membership(data(indexed_design_from_matrix(guides)))
+    for actual, expected in zip(indexed, dense, strict=True):
+        np.testing.assert_array_equal(actual, expected)
+
+
+def test_exclude_targets_remaps_an_indexed_design_in_compact_form() -> None:
+    matrix = np.asarray(
+        [[1, 0, 0], [0, 1, 0], [0, 0, 1], [0, 1, 1], [0, 0, 1]], dtype=np.float32
+    )
+    data = PerTurboData(
+        counts=jnp.ones((5, 1), dtype=jnp.float32),
+        pert_id=indexed_design_from_matrix(matrix),
+        pert_names=["NTC", "a", "b"],
+        gene_names=["g"],
+        size_factors=jnp.zeros((5, 1), dtype=jnp.float32),
+    )
+
+    kept = exclude_targets(data, ["NTC"])
+    assert kept is not None and isinstance(kept.pert_id, IndexedDesignMatrix)
+    assert kept.pert_names == ["a", "b"]
+    np.testing.assert_array_equal(
+        np.asarray(indexed_design_to_dense(kept.pert_id)),
+        np.asarray([[1, 0], [0, 1], [1, 1], [0, 1]], dtype=np.float32),
+    )

--- a/tests/test_crt_pool_auto.py
+++ b/tests/test_crt_pool_auto.py
@@ -4,6 +4,8 @@ Both pools are valid for a screen whose realised MOI is a little above one, and 
 answer different questions, so the rule is: test against a control pool when cells
 carry about one perturbation each and there are enough unperturbed cells to be a pool.
 """
+from types import SimpleNamespace
+
 import anndata as ad
 import mudata as md
 import numpy as np
@@ -56,6 +58,41 @@ def test_a_high_moi_screen_reads_as_high():
     assert out["median_guides_per_cell"] >= 1.5
 
 
+def test_backed_sparse_high_moi_measurement_streams_csr_dataset(tmp_path):
+    assignments = sp.csr_matrix(
+        np.array(
+            [
+                [1, 1, 0, 0],
+                [0, 1, 1, 0],
+                [0, 0, 0, 0],
+                [1, 0, 0, 0],
+            ],
+            dtype=np.int8,
+        )
+    )
+    guide = ad.AnnData(
+        X=assignments,
+        var=pd.DataFrame(index=["non-targeting_0", "g1", "g2", "g3"]),
+    )
+    path = tmp_path / "backed-guides.h5ad"
+    guide.write_h5ad(path)
+    backed = ad.read_h5ad(path, backed="r")
+    try:
+        assert not hasattr(backed.X, "tocsr")
+        out = measure_realized_moi(
+            SimpleNamespace(mod={"grna": backed}),
+            perturbation_modality_key="grna",
+            perturbation_layer=None,
+            control_substring="non-targeting",
+        )
+    finally:
+        backed.file.close()
+
+    assert out["median_guides_per_cell"] == 1.5
+    assert out["mean_guides_per_cell"] == 1.25
+    assert out["n_control_cells"] == 1
+
+
 def test_only_cells_carrying_nothing_but_controls_count_as_controls():
     """A cell with a control guide and a targeting guide is perturbed, not a control."""
     n = 6
@@ -99,7 +136,10 @@ def test_controls_are_recognised_through_the_element_they_map_to():
     # guides 0-3 map to two control elements, the rest to targeting elements
     element_names = ["non-targeting|1", "non-targeting|2", "GENE_A", "GENE_B"]
     mapping = np.zeros((n_guides, 4), dtype=np.float32)
-    mapping[[0, 1], 0] = 1; mapping[[2, 3], 1] = 1; mapping[4:7, 2] = 1; mapping[7:, 3] = 1
+    mapping[[0, 1], 0] = 1
+    mapping[[2, 3], 1] = 1
+    mapping[4:7, 2] = 1
+    mapping[7:, 3] = 1
     guide.varm["element_map"] = mapping
     guide.uns["element_names"] = element_names
     rna = ad.AnnData(X=np.ones((n_cells, 2), dtype=np.float32), var=pd.DataFrame(index=["a", "b"]))

--- a/tests/test_gene_chunk_cli.py
+++ b/tests/test_gene_chunk_cli.py
@@ -1,0 +1,294 @@
+"""End-to-end CLI coverage for disk-backed stage-two gene blocks."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import anndata as ad
+import jax.numpy as jnp
+import mudata as md
+import numpy as np
+import pandas as pd
+import scipy.sparse as sp
+
+import perturbo.api as api
+import perturbo.cli as cli_module
+from perturbo.crt import ChunkCRTResult
+from perturbo.io import load_fit_bundle
+from perturbo.sparse_design import IndexedDesignMatrix, indexed_design_to_dense
+
+
+GENES = [f"gene_{index}" for index in range(5)]
+GUIDES = ["ctrl", "guide_a", "guide_b"]
+ELEMENTS = ["ctrl", "element_a", "element_b"]
+
+
+def _write_cooccurring_screen(path: Path) -> tuple[np.ndarray, np.ndarray]:
+    counts = np.array(
+        [
+            [1, 2, 3, 4, 5],
+            [3, 1, 4, 1, 5],
+            [2, 7, 1, 8, 2],
+            [6, 1, 8, 0, 3],
+            [5, 9, 2, 6, 5],
+            [3, 5, 8, 9, 7],
+            [9, 3, 2, 3, 8],
+            [4, 6, 2, 6, 4],
+        ],
+        dtype=np.int32,
+    )
+    assignments = np.array(
+        [
+            [1, 0, 0],
+            [1, 0, 0],
+            [0, 1, 0],
+            [0, 0, 1],
+            [0, 1, 1],
+            [0, 1, 1],
+            [0, 1, 0],
+            [0, 0, 1],
+        ],
+        dtype=np.float32,
+    )
+    obs = pd.DataFrame(index=[f"cell_{index}" for index in range(counts.shape[0])])
+    rna = ad.AnnData(
+        X=sp.csr_matrix(counts),
+        obs=obs.copy(),
+        var=pd.DataFrame(index=GENES),
+    )
+    guides = ad.AnnData(
+        X=sp.csr_matrix(assignments),
+        obs=obs.copy(),
+        var=pd.DataFrame(index=GUIDES),
+    )
+    guides.varm["mapping"] = pd.DataFrame(
+        np.eye(len(GUIDES), dtype=np.float32),
+        index=GUIDES,
+        columns=ELEMENTS,
+    )
+    md.MuData({"rna": rna, "grna": guides}).write_h5mu(path)
+    return counts, assignments
+
+
+def _control_fit(data, **kwargs):
+    del kwargs
+    n_genes = int(data.counts.shape[1])
+    return api.ControlFit(
+        beta_0=jnp.arange(n_genes, dtype=jnp.float32) + 10.0,
+        theta=jnp.arange(n_genes, dtype=jnp.float32) + 20.0,
+        noise_scale=jnp.ones(n_genes, dtype=jnp.float32),
+        factor_loadings=None,
+        factor_scores=None,
+        factor_center=None,
+        pca_loadings=None,
+        size_factors=data.size_factors,
+        losses=jnp.array([], dtype=jnp.float32),
+        svi_result=None,
+    )
+
+
+def _gene_values(row_count: int, gene_names: list[str], *, base: float) -> np.ndarray:
+    gene_ids = np.array([GENES.index(name) for name in gene_names], dtype=np.float32)
+    row_ids = np.arange(row_count, dtype=np.float32)[:, None]
+    return base + 100.0 * row_ids + gene_ids[None, :]
+
+
+def test_backed_gene_blocks_keep_the_joint_design_offsets_and_combined_posterior(
+    tmp_path, monkeypatch
+) -> None:
+    source = tmp_path / "screen.h5mu"
+    out = tmp_path / "out"
+    counts, assignments = _write_cooccurring_screen(source)
+
+    original_load = api.load_analysis_cells
+    requested_gene_indices: list[slice | None] = []
+    fit_calls: list[dict[str, np.ndarray | list[str] | tuple[int, ...]]] = []
+
+    def recording_load(*args, **kwargs):
+        requested_gene_indices.append(kwargs.get("selected_gene_indices"))
+        return original_load(*args, **kwargs)
+
+    def beta_fit(data, control, **kwargs):
+        del kwargs
+        assert isinstance(data.pert_id, IndexedDesignMatrix)
+        dense_elements = np.asarray(indexed_design_to_dense(data.pert_id))
+        np.testing.assert_array_equal(dense_elements, assignments)
+        # Shared guide effects need only the grouped element design. Avoiding a
+        # second indexed guide matrix is part of the memory-bounded path.
+        assert data.guide_matrix is None
+
+        names = list(data.gene_names)
+        gene_ids = np.array([GENES.index(name) for name in names])
+        np.testing.assert_array_equal(np.asarray(data.counts), counts[:, gene_ids])
+        np.testing.assert_array_equal(np.asarray(control.beta_0), 10.0 + gene_ids)
+        np.testing.assert_array_equal(np.asarray(control.theta), 20.0 + gene_ids)
+        fit_calls.append(
+            {
+                "shape": tuple(data.counts.shape),
+                "genes": names,
+                "offsets": np.asarray(data.size_factors).copy(),
+            }
+        )
+
+        n_elements = len(data.pert_names)
+        return api.BetaFit(
+            posterior_mean=jnp.asarray(_gene_values(n_elements, names, base=0.0)),
+            posterior_scale=jnp.asarray(_gene_values(n_elements, names, base=1_000.0)),
+            z_values=jnp.asarray(_gene_values(n_elements, names, base=2_000.0)),
+            losses=jnp.array([], dtype=jnp.float32),
+            svi_result=None,
+        )
+
+    monkeypatch.setattr(api, "load_analysis_cells", recording_load)
+    monkeypatch.setattr(api, "fit_control", _control_fit)
+    monkeypatch.setattr(api, "fit_perturbation_effects", beta_fit)
+    monkeypatch.setattr(api, "_save_loss_plot", lambda *args, **kwargs: None)
+    monkeypatch.setattr(api, "_save_multi_loss_plot", lambda *args, **kwargs: None)
+
+    api.main(
+        [
+            "--input",
+            str(source),
+            "--out-dir",
+            str(out),
+            "--modality-key",
+            "rna",
+            "--perturbation-modality-key",
+            "grna",
+            "--perturbation-element-varm-key",
+            "mapping",
+            "--control-substring",
+            "ctrl",
+            "--likelihood",
+            "negbin",
+            "--gene-chunk-size",
+            "2",
+            "--num-steps-control",
+            "1",
+            "--num-steps-betas",
+            "1",
+            "--backed",
+            "--no-crt",
+        ]
+    )
+
+    assert requested_gene_indices == [slice(0, 2), slice(2, 4), slice(4, 5)]
+    assert [call["shape"] for call in fit_calls] == [(8, 2), (8, 2), (8, 1)]
+    assert [call["genes"] for call in fit_calls] == [GENES[:2], GENES[2:4], GENES[4:]]
+
+    control_center = np.log1p(counts[:2].sum(axis=1)).mean()
+    expected_offsets = (np.log1p(counts.sum(axis=1)) - control_center)[:, None]
+    for call in fit_calls:
+        np.testing.assert_allclose(call["offsets"], expected_offsets, rtol=1e-6, atol=1e-6)
+
+    bundle = load_fit_bundle(out)
+    assert bundle["metadata"]["gene_names"] == GENES
+    assert bundle["metadata"]["perturbation_names"] == ELEMENTS
+    np.testing.assert_array_equal(
+        bundle["beta_arrays"]["posterior_mean"],
+        _gene_values(len(ELEMENTS), GENES, base=0.0),
+    )
+    np.testing.assert_array_equal(
+        bundle["beta_arrays"]["posterior_scale"],
+        _gene_values(len(ELEMENTS), GENES, base=1_000.0),
+    )
+    assert bundle["guide_posteriors"] == {}
+
+    effects = pd.read_parquet(out / "element_effects.parquet")
+    np.testing.assert_array_equal(effects["element"], np.repeat(ELEMENTS, len(GENES)))
+    np.testing.assert_array_equal(effects["gene"], np.tile(GENES, len(ELEMENTS)))
+    np.testing.assert_array_equal(
+        effects["posterior_mean"], _gene_values(len(ELEMENTS), GENES, base=0.0).reshape(-1)
+    )
+
+
+def test_gene_block_crt_only_has_the_same_screen_wide_p_and_q_values(tmp_path, monkeypatch) -> None:
+    source = tmp_path / "screen.h5mu"
+    _write_cooccurring_screen(source)
+
+    def baseline(data, control, **kwargs):
+        del control, kwargs
+        return SimpleNamespace(null_check=SimpleNamespace(describe=lambda: "stub null"))
+
+    def crt_result(_baseline, data, **kwargs):
+        del _baseline, kwargs
+        gene_ids = np.array([GENES.index(name) for name in data.gene_names], dtype=np.float64)
+        row_ids = np.arange(len(data.pert_names), dtype=np.float64)[:, None]
+        p_value = 0.01 * (row_ids + 1.0) + 0.001 * (gene_ids[None, :] + 1.0)
+        shape = p_value.shape
+        zeros = np.zeros(shape, dtype=np.float64)
+        return ChunkCRTResult(
+            observed_score=1.0 - p_value,
+            p_value=np.full(shape, np.nan),
+            null_converged=np.ones(shape, dtype=bool),
+            target_names=tuple(data.pert_names),
+            gene_names=tuple(data.gene_names),
+            num_resamples=0,
+            parametric={
+                "saddlepoint": {
+                    "p_value": p_value,
+                    "log_p_value": np.log(p_value),
+                    "valid": np.ones(shape, dtype=bool),
+                    "used_screen": np.zeros(shape, dtype=bool),
+                }
+            },
+            null_summaries={
+                "crt_null_mean": zeros,
+                "crt_null_variance": np.ones(shape),
+                "crt_null_skewness": zeros,
+                "crt_null_excess_kurtosis": zeros,
+            },
+            resampling_mechanism="propensity",
+            saddlepoint_only=True,
+        )
+
+    monkeypatch.setattr(api, "fit_control", _control_fit)
+    monkeypatch.setattr(api, "_save_loss_plot", lambda *args, **kwargs: None)
+    monkeypatch.setattr(cli_module, "prepare_crt_baseline", baseline)
+    monkeypatch.setattr(cli_module, "prepare_all_cells_propensity", lambda *args, **kwargs: object())
+    monkeypatch.setattr(cli_module, "run_crt_all_cells", crt_result)
+
+    def run(out: Path, *, chunked: bool) -> pd.DataFrame:
+        argv = [
+            "--input",
+            str(source),
+            "--out-dir",
+            str(out),
+            "--modality-key",
+            "rna",
+            "--perturbation-modality-key",
+            "grna",
+            "--perturbation-element-varm-key",
+            "mapping",
+            "--control-substring",
+            "ctrl",
+            "--likelihood",
+            "negbin",
+            "--num-steps-control",
+            "1",
+            "--num-steps-betas",
+            "1",
+            "--backed",
+            "--crt",
+            "--crt-only",
+            "--crt-pool",
+            "all-cells",
+            "--crt-mechanism",
+            "propensity",
+            "--crt-tail-families",
+            "saddlepoint",
+            "--crt-saddlepoint-only",
+            "--no-save-model-params",
+        ]
+        if chunked:
+            argv.extend(["--gene-chunk-size", "2"])
+        api.main(argv)
+        return pd.read_parquet(out / "element_effects.parquet").sort_values(
+            ["element", "gene"], ignore_index=True
+        )
+
+    full = run(tmp_path / "full", chunked=False)
+    chunked = run(tmp_path / "chunked", chunked=True)
+    for column in ("crt_saddlepoint_p_value", "crt_saddlepoint_q_value"):
+        np.testing.assert_allclose(chunked[column], full[column], rtol=0.0, atol=0.0)

--- a/tests/test_gene_chunked_svi.py
+++ b/tests/test_gene_chunked_svi.py
@@ -1,0 +1,356 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from types import SimpleNamespace
+
+import anndata as ad
+import jax.numpy as jnp
+import mudata as md
+import numpy as np
+import numpyro
+import pandas as pd
+import scipy.sparse as sp
+
+import perturbo.core as core
+from perturbo.core import ControlFit, SVIConfig, fit_perturbation_effects, load_analysis_cells, load_controls
+from perturbo.model import GuideSharedNegativeBinomialModel, NegBinModel
+from perturbo.sparse_design import IndexedDesignMatrix, indexed_design_to_dense
+
+
+def _control_fit(num_genes: int) -> ControlFit:
+    return ControlFit(
+        beta_0=jnp.zeros(num_genes, dtype=jnp.float32),
+        theta=jnp.full(num_genes, 10.0, dtype=jnp.float32),
+        noise_scale=jnp.ones(num_genes, dtype=jnp.float32),
+        factor_loadings=None,
+        factor_scores=None,
+        factor_center=None,
+        pca_loadings=None,
+        size_factors=jnp.zeros((2, 1), dtype=jnp.float32),
+        losses=jnp.array([]),
+        svi_result=None,
+    )
+
+
+def _high_moi_data() -> tuple[md.MuData, np.ndarray, np.ndarray]:
+    counts = np.array(
+        [[2, 1, 9], [4, 0, 1], [3, 2, 5], [2, 1, 4], [8, 1, 2], [7, 0, 3], [9, 1, 0], [6, 2, 1]],
+        dtype=np.int32,
+    )
+    guides = np.array(
+        [[0, 0], [1, 0], [0, 1], [1, 1], [1, 0], [0, 1], [1, 1], [0, 0]],
+        dtype=np.int8,
+    )
+    obs = pd.DataFrame(index=[f"c{i}" for i in range(counts.shape[0])])
+    rna = ad.AnnData(X=counts, obs=obs, var=pd.DataFrame(index=["g0", "g1", "g2"]))
+    perturbations = ad.AnnData(
+        X=sp.csr_matrix(guides),
+        obs=obs.copy(),
+        var=pd.DataFrame(index=["guide_A", "guide_B"]),
+    )
+    perturbations.varm["targets"] = pd.DataFrame(
+        np.eye(2, dtype=np.float32),
+        index=perturbations.var_names,
+        columns=["target_A", "target_B"],
+    )
+    return md.MuData({"rna": rna, "pert": perturbations}), counts, guides
+
+
+def test_gene_chunk_loads_only_selected_counts_and_uses_full_panel_offsets(monkeypatch) -> None:
+    data, counts, guides = _high_moi_data()
+    dense_shapes: list[tuple[int, ...]] = []
+    original_to_dense = core._to_dense
+
+    def recording_to_dense(matrix):
+        dense_shapes.append(tuple(matrix.shape))
+        return original_to_dense(matrix)
+
+    monkeypatch.setattr(core, "_to_dense", recording_to_dense)
+    loaded = load_analysis_cells(
+        data,
+        modality_key="rna",
+        perturbation_modality_key="pert",
+        perturbation_element_varm_key="targets",
+        retain_guide_structure=True,
+        selected_gene_indices=slice(0, 2),
+        indexed_perturbation_design=True,
+    )
+
+    np.testing.assert_array_equal(np.asarray(loaded.counts), counts[:, :2])
+    assert loaded.gene_names == ["g0", "g1"]
+    assert (counts.shape[0], counts.shape[1]) not in dense_shapes
+    expected_offsets = np.log1p(counts.sum(axis=1)) - np.mean(np.log1p(counts.sum(axis=1)))
+    np.testing.assert_allclose(np.asarray(loaded.size_factors).reshape(-1), expected_offsets, rtol=1e-6)
+    assert isinstance(loaded.pert_id, IndexedDesignMatrix)
+    assert isinstance(loaded.guide_matrix, IndexedDesignMatrix)
+    np.testing.assert_array_equal(np.asarray(indexed_design_to_dense(loaded.pert_id)), guides)
+
+
+def test_backed_gene_chunk_does_not_materialize_raw_or_layers(tmp_path, monkeypatch) -> None:
+    cell_names = ["c0", "c1", "c2", "c3"]
+    counts = np.arange(24, dtype=np.int32).reshape(4, 6)
+    obs = pd.DataFrame(index=cell_names)
+    rna = ad.AnnData(X=sp.csr_matrix(counts), obs=obs, var=pd.DataFrame(index=[f"g{i}" for i in range(6)]))
+    rna.raw = rna.copy()
+    rna.layers["unused_full_panel"] = sp.csr_matrix(counts + 1)
+    rna_path = tmp_path / "rna-with-raw.h5ad"
+    rna.write_h5ad(rna_path)
+    backed_rna = ad.read_h5ad(rna_path, backed="r")
+
+    guide_assignments = sp.csr_matrix(
+        np.array([[1, 0, 0], [0, 1, 1], [0, 1, 0], [0, 0, 0]], dtype=np.int8)
+    )
+    perturbations = ad.AnnData(
+        X=guide_assignments,
+        obs=obs.copy(),
+        var=pd.DataFrame(index=["ctrl", "guide_A", "guide_B"]),
+    )
+    perturbations.varm["targets"] = sp.eye(3, dtype=np.int8, format="csr")
+    perturbations.uns["target_names"] = ["ctrl", "target_A", "target_B"]
+    data = SimpleNamespace(mod={"rna": backed_rna, "pert": perturbations})
+
+    def fail_to_memory(self, *args, **kwargs):
+        raise AssertionError("loaders must not materialize the whole backed AnnData object")
+
+    monkeypatch.setattr(ad.AnnData, "to_memory", fail_to_memory)
+    try:
+        loaded = load_analysis_cells(
+            data,
+            modality_key="rna",
+            perturbation_modality_key="pert",
+            perturbation_element_varm_key="targets",
+            perturbation_element_names_uns_key="target_names",
+            selected_gene_indices=slice(2, 4),
+            indexed_perturbation_design=True,
+        )
+        controls = load_controls(
+            data,
+            modality_key="rna",
+            perturbation_modality_key="pert",
+            perturbation_element_varm_key="targets",
+            perturbation_element_names_uns_key="target_names",
+            control_selector="ctrl",
+            max_control_cells=None,
+        )
+    finally:
+        backed_rna.file.close()
+
+    np.testing.assert_array_equal(np.asarray(loaded.counts), counts[:, 2:4])
+    np.testing.assert_array_equal(np.asarray(controls.counts), counts[[0]])
+
+
+def test_counts_derived_offsets_keep_zero_rows_and_control_center() -> None:
+    center = float(np.log1p(9.0))
+    offsets, loaded_center = core._load_observed_size_factors(
+        pd.DataFrame(index=["zero", "positive"]),
+        np.array([[0], [3]], dtype=np.int32),
+        library_size_center_log_mean=center,
+        counts_library_sizes=np.array([0, 9], dtype=np.float64),
+    )
+
+    assert loaded_center == center
+    np.testing.assert_allclose(np.asarray(offsets).reshape(-1), [-center, 0.0], atol=1e-6)
+
+
+def test_control_loader_densifies_sparse_guides_only_after_filter_and_cap(monkeypatch) -> None:
+    num_cells, num_guides = 40, 200
+    obs = pd.DataFrame(index=[f"c{i}" for i in range(num_cells)])
+    rna = ad.AnnData(
+        X=np.ones((num_cells, 2), dtype=np.int32),
+        obs=obs,
+        var=pd.DataFrame(index=["g0", "g1"]),
+    )
+    guide_columns = np.concatenate([np.zeros(20, dtype=np.int64), np.arange(1, 21, dtype=np.int64)])
+    assignments = sp.csr_matrix(
+        (np.ones(num_cells), (np.arange(num_cells), guide_columns)),
+        shape=(num_cells, num_guides),
+    )
+    perturbations = ad.AnnData(
+        X=assignments,
+        obs=obs.copy(),
+        var=pd.DataFrame(index=["ctrl"] + [f"guide_{i}" for i in range(1, num_guides)]),
+    )
+    data = md.MuData({"rna": rna, "pert": perturbations})
+    dense_shapes: list[tuple[int, ...]] = []
+    original_to_dense = core._to_dense
+
+    def recording_to_dense(matrix):
+        dense_shapes.append(tuple(matrix.shape))
+        return original_to_dense(matrix)
+
+    monkeypatch.setattr(core, "_to_dense", recording_to_dense)
+    controls = load_controls(
+        data,
+        modality_key="rna",
+        perturbation_modality_key="pert",
+        control_selector="ctrl",
+        max_control_cells=5,
+    )
+
+    assert controls.counts.shape[0] == 5
+    assert (num_cells, num_guides) not in dense_shapes
+    assert (5, 1) in dense_shapes
+
+
+def test_low_moi_target_subset_stays_sparse_until_rows_and_columns_are_selected(monkeypatch) -> None:
+    num_cells, num_guides = 40, 200
+    obs = pd.DataFrame(index=[f"c{i}" for i in range(num_cells)])
+    rna = ad.AnnData(
+        X=np.ones((num_cells, 2), dtype=np.int32),
+        obs=obs,
+        var=pd.DataFrame(index=["g0", "g1"]),
+    )
+    columns = np.arange(num_cells, dtype=np.int64)
+    perturbations = ad.AnnData(
+        X=sp.csr_matrix(
+            (np.ones(num_cells), (np.arange(num_cells), columns)),
+            shape=(num_cells, num_guides),
+        ),
+        obs=obs.copy(),
+        var=pd.DataFrame(index=[f"guide_{i}" for i in range(num_guides)]),
+    )
+    perturbations.varm["targets"] = sp.eye(num_guides, dtype=np.int8, format="csr")
+    perturbations.uns["target_names"] = [f"target_{i}" for i in range(num_guides)]
+    data = md.MuData({"rna": rna, "pert": perturbations})
+    dense_shapes: list[tuple[int, ...]] = []
+    original_to_dense = core._to_dense
+
+    def recording_to_dense(matrix):
+        dense_shapes.append(tuple(matrix.shape))
+        return original_to_dense(matrix)
+
+    monkeypatch.setattr(core, "_to_dense", recording_to_dense)
+    loaded = load_analysis_cells(
+        data,
+        modality_key="rna",
+        perturbation_modality_key="pert",
+        perturbation_element_varm_key="targets",
+        perturbation_element_names_uns_key="target_names",
+        selected_perturbations=["target_0", "target_1"],
+        retain_guide_structure=True,
+    )
+
+    assert loaded.counts.shape == (2, 2)
+    assert loaded.pert_id.shape == (2, 2)
+    assert loaded.guide_matrix.shape == (2, 2)
+    assert (num_cells, num_guides) not in dense_shapes
+
+
+def test_sparse_grouping_uses_positive_presence_without_int8_overflow() -> None:
+    num_guides = 130
+    assignments = sp.csr_matrix(np.full((1, num_guides), 0.5, dtype=np.float32))
+    mapping = sp.csr_matrix(np.ones((num_guides, 1), dtype=np.int8))
+
+    grouped = core._group_perturbation_matrix_by_element(assignments, mapping, preserve_sparse=True)
+
+    np.testing.assert_array_equal(grouped.toarray(), [[1]])
+
+
+def test_indexed_high_moi_design_runs_minibatched_svi() -> None:
+    data, _, _ = _high_moi_data()
+    loaded = load_analysis_cells(
+        data,
+        modality_key="rna",
+        perturbation_modality_key="pert",
+        perturbation_element_varm_key="targets",
+        retain_guide_structure=True,
+        selected_gene_indices=slice(0, 2),
+        indexed_perturbation_design=True,
+    )
+
+    fit = fit_perturbation_effects(
+        loaded,
+        _control_fit(2),
+        num_steps=1,
+        svi_config=SVIConfig(),
+        model_name="nb",
+        use_observed_size_factors=True,
+        minibatch_size=4,
+    )
+
+    assert fit.posterior_mean.shape == (2, 2)
+    assert fit.losses.shape == (1,)
+
+
+def test_subset_control_fit_genes_slices_every_gene_axis() -> None:
+    control = _control_fit(4)
+    control = replace(
+        control,
+        beta_0=jnp.arange(4, dtype=jnp.float32),
+        covariate_coef=jnp.arange(8, dtype=jnp.float32).reshape(2, 4),
+    )
+
+    chunk = core.subset_control_fit_genes(control, slice(1, 3))
+
+    np.testing.assert_array_equal(np.asarray(chunk.beta_0), [1, 2])
+    np.testing.assert_array_equal(np.asarray(chunk.covariate_coef), [[1, 2], [5, 6]])
+
+
+def _observation_log_prob(counts, design, beta, beta_0, theta, offsets) -> float:
+    conditioned = numpyro.handlers.condition(
+        NegBinModel,
+        data={"beta": beta, "beta_0": beta_0, "theta": theta},
+    )
+    trace = numpyro.handlers.trace(numpyro.handlers.seed(conditioned, rng_seed=4)).get_trace(
+        counts,
+        design,
+        size_factors=offsets,
+        num_cells=counts.shape[0],
+        num_genes=counts.shape[1],
+        num_perts=beta.shape[0],
+    )
+    return float(jnp.sum(trace["obs"]["fn"].log_prob(counts)))
+
+
+def test_indexed_joint_likelihood_equals_dense_and_gene_blocks() -> None:
+    counts = jnp.array([[3, 1, 2], [5, 0, 4], [2, 6, 1]], dtype=jnp.int32)
+    dense = np.array([[1, 0], [1, 1], [0, 1]], dtype=np.float32)
+    indexed = core.indexed_design_from_matrix(dense)
+    beta = jnp.array([[0.2, -0.1, 0.3], [-0.4, 0.5, 0.1]], dtype=jnp.float32)
+    beta_0 = jnp.array([1.0, 0.7, 1.2], dtype=jnp.float32)
+    theta = jnp.array([10.0, 8.0, 12.0], dtype=jnp.float32)
+    offsets = jnp.array([[0.0], [0.1], [-0.2]], dtype=jnp.float32)
+
+    joint_dense = _observation_log_prob(counts, jnp.asarray(dense), beta, beta_0, theta, offsets)
+    joint_indexed = _observation_log_prob(counts, indexed, beta, beta_0, theta, offsets)
+    split = sum(
+        _observation_log_prob(
+            counts[:, gene_slice],
+            indexed,
+            beta[:, gene_slice],
+            beta_0[gene_slice],
+            theta[gene_slice],
+            offsets,
+        )
+        for gene_slice in (slice(0, 2), slice(2, 3))
+    )
+
+    np.testing.assert_allclose(joint_indexed, joint_dense, rtol=1e-6)
+    np.testing.assert_allclose(split, joint_dense, rtol=1e-6)
+
+
+def test_shared_mean_counts_an_element_once_when_two_guides_target_it() -> None:
+    beta = jnp.array([[np.log(2.0)]], dtype=jnp.float32)
+    conditioned = numpyro.handlers.condition(
+        GuideSharedNegativeBinomialModel,
+        data={
+            "beta": beta,
+            "beta_0": jnp.array([np.log(10.0)], dtype=jnp.float32),
+            "theta": jnp.array([50.0], dtype=jnp.float32),
+            "guide_dispersion_excess_inverse": jnp.array([[0.1], [0.1]], dtype=jnp.float32),
+        },
+    )
+    trace = numpyro.handlers.trace(numpyro.handlers.seed(conditioned, rng_seed=9)).get_trace(
+        jnp.array([[0]], dtype=jnp.int32),
+        jnp.array([[1]], dtype=jnp.bool_),
+        size_factors=jnp.zeros((1, 1), dtype=jnp.float32),
+        guide_matrix=jnp.array([[1.0, 1.0]], dtype=jnp.float32),
+        guide_to_element=jnp.array([[1.0], [1.0]], dtype=jnp.float32),
+        num_cells=1,
+        num_genes=1,
+        num_perts=1,
+        num_guides=2,
+        fit_perturbation_dispersion=True,
+    )
+
+    np.testing.assert_allclose(np.asarray(trace["obs"]["fn"].mean), [[20.0]], rtol=1e-5)

--- a/tests/test_high_moi.py
+++ b/tests/test_high_moi.py
@@ -471,7 +471,7 @@ def test_load_analysis_cells_high_moi_grouped_varm_requires_names_or_uns_key() -
         )
 
 
-def test_load_analysis_cells_high_moi_grouped_varm_uses_uns_names_for_subset() -> None:
+def test_load_analysis_cells_high_moi_grouped_varm_rejects_coassigned_subset() -> None:
     data = _make_mudata()
     data["pert"].varm["element_targeted"] = np.array(
         [
@@ -483,9 +483,29 @@ def test_load_analysis_cells_high_moi_grouped_varm_uses_uns_names_for_subset() -
     )
     data["pert"].uns["element_names"] = ["elem1", "elem2"]
 
+    with pytest.raises(ValueError, match="also carry excluded effects"):
+        load_analysis_cells(
+            data,
+            perturbation_key=None,
+            modality_key="rna",
+            perturbation_modality_key="pert",
+            perturbation_element_varm_key="element_targeted",
+            perturbation_element_names_uns_key="element_names",
+            selected_perturbations=["elem2"],
+        )
+
+
+def test_load_analysis_cells_grouped_subset_remains_valid_when_mutually_exclusive() -> None:
+    data = _make_mudata()
+    data["pert"].X[2, 0] = 0
+    data["pert"].varm["element_targeted"] = np.array(
+        [[1, 0], [0, 1], [0, 1]],
+        dtype=np.int8,
+    )
+    data["pert"].uns["element_names"] = ["elem1", "elem2"]
+
     analysis_data = load_analysis_cells(
         data,
-        perturbation_key=None,
         modality_key="rna",
         perturbation_modality_key="pert",
         perturbation_element_varm_key="element_targeted",
@@ -494,12 +514,7 @@ def test_load_analysis_cells_high_moi_grouped_varm_uses_uns_names_for_subset() -
     )
 
     assert analysis_data.pert_names == ["elem2"]
-    assert analysis_data.pert_id.shape == (1, 1)
     assert np.array_equal(np.asarray(analysis_data.pert_id), np.array([[1]], dtype=np.int8))
-    assert np.array_equal(
-        np.asarray(analysis_data.counts),
-        np.array([[0, 0, 3]], dtype=np.int32),
-    )
 
 
 def test_load_analysis_cells_high_moi_grouped_varm_accepts_sparse_mapping() -> None:

--- a/tests/test_log_normal_negative_binomial.py
+++ b/tests/test_log_normal_negative_binomial.py
@@ -4,14 +4,41 @@ from __future__ import annotations
 
 import jax
 import jax.numpy as jnp
+import numpy as np
 import numpyro
 import numpyro.distributions as dist
 from numpyro.infer import SVI, Trace_ELBO
 from numpyro.infer.autoguide import AutoNormal
+from scipy.integrate import quad
+from scipy.special import expit
+from scipy.stats import nbinom, norm
 
 from perturbo.api import PerTurboData, fit_perturbation_effects, fit_control
 from perturbo.log_normal_negative_binomial import LogNormalNegativeBinomial
 from perturbo.model import LogNormalNegativeBinomialModel
+
+
+def test_nonzero_noise_likelihood_matches_independent_integration() -> None:
+    total_count, logits, noise = 5.0, 0.0, 0.5
+    distribution = LogNormalNegativeBinomial(
+        jnp.asarray(total_count), jnp.asarray(logits), jnp.asarray(noise), num_quad_points=32
+    )
+    values = np.array([0, 1, 5, 15])
+    expected = np.array([
+        quad(
+            lambda z: nbinom.pmf(value, total_count, expit(-logits - noise * z)) * norm.pdf(z),
+            -10.0,
+            10.0,
+            epsabs=1e-12,
+        )[0]
+        for value in values
+    ])
+    np.testing.assert_allclose(np.exp(distribution.log_prob(values)), expected, rtol=1e-6, atol=1e-10)
+
+
+def test_sample_shape_is_applied_once() -> None:
+    distribution = LogNormalNegativeBinomial(jnp.array([3.0, 5.0]), jnp.zeros(2), jnp.full(2, 0.5))
+    assert distribution.sample(jax.random.key(0), sample_shape=(3, 4)).shape == (3, 4, 2)
 
 
 def test_lognormal_nb_matches_negative_binomial_at_zero_noise() -> None:

--- a/tests/test_propensity_rank.py
+++ b/tests/test_propensity_rank.py
@@ -1,0 +1,59 @@
+"""Rank-deficient propensity designs must not create synthetic predictors."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from perturbo._internal.high_moi.resampling import (
+    fit_propensity_probabilities,
+    propensity_basis,
+)
+
+
+def test_zero_and_duplicate_columns_leave_an_intercept_only_fit_unchanged() -> None:
+    outcome = np.zeros((1, 100), dtype=np.float32)
+    outcome[0, :20] = 1.0
+    intercept = np.ones((100, 1), dtype=np.float32)
+
+    expected = np.asarray(fit_propensity_probabilities(outcome, intercept))
+    variants = (
+        np.column_stack([intercept, np.zeros(100)]),
+        np.column_stack([intercept, intercept]),
+        np.column_stack([intercept, 1_000.0 * intercept]),
+    )
+    for design in variants:
+        actual = np.asarray(fit_propensity_probabilities(outcome, design))
+        np.testing.assert_allclose(actual, expected, rtol=1e-6, atol=1e-7)
+        np.testing.assert_allclose(actual, 0.2, rtol=1e-6, atol=1e-7)
+
+
+def test_propensity_fit_is_invariant_to_units_and_row_permutation() -> None:
+    rng = np.random.default_rng(9)
+    covariate = np.linspace(-2.0, 2.0, 240, dtype=np.float32)
+    probability = 1.0 / (1.0 + np.exp(-(-0.8 + 0.7 * covariate)))
+    outcome = (rng.random(covariate.size) < probability).astype(np.float32)[None, :]
+    design = np.column_stack([np.ones(covariate.size), covariate]).astype(np.float32)
+    expected = np.asarray(fit_propensity_probabilities(outcome, design))
+
+    redundant = np.column_stack(
+        [np.ones(covariate.size), 1_000.0 * covariate, covariate, np.zeros(covariate.size)]
+    ).astype(np.float32)
+    rescaled = np.asarray(fit_propensity_probabilities(outcome, redundant))
+    np.testing.assert_allclose(rescaled, expected, rtol=2e-5, atol=2e-6)
+
+    order = rng.permutation(covariate.size)
+    permuted = np.asarray(fit_propensity_probabilities(outcome[:, order], redundant[order]))
+    np.testing.assert_allclose(permuted[:, np.argsort(order)], expected, rtol=2e-5, atol=2e-6)
+
+
+def test_large_screens_keep_real_correlated_covariate_directions() -> None:
+    """Float32 source precision must not turn the row count into a rank cutoff."""
+
+    rng = np.random.default_rng(31)
+    rows = 200_000
+    first = rng.normal(size=rows).astype(np.float32)
+    second = (first + 0.01 * rng.normal(size=rows)).astype(np.float32)
+    design = np.column_stack([np.ones(rows, dtype=np.float32), first, second])
+
+    basis = np.asarray(propensity_basis(design))
+    assert basis.shape == (rows, 3)

--- a/tests/test_saved_model_correctness.py
+++ b/tests/test_saved_model_correctness.py
@@ -1,0 +1,392 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import anndata as ad
+import jax.numpy as jnp
+import mudata as md
+import numpy as np
+import pandas as pd
+
+import perturbo.api as api
+import perturbo.cli as cli_module
+import perturbo.simulation.fitted as fitted_simulation
+from perturbo.inference import PerTurboModel
+from perturbo.io import MuDataSetup
+from perturbo.simulation.fitted import _resolve_size_factors
+
+
+def test_bundle_offsets_slice_original_rows_before_reading_counts() -> None:
+    counts = np.arange(24, dtype=np.int32).reshape(6, 4)
+    selected_rows = np.array([1, 3, 4], dtype=np.int64)
+    reads: list[np.ndarray] = []
+
+    class SparseLikeBlock:
+        def __init__(self, values):
+            self.values = values
+
+        def sum(self, axis, dtype=None):
+            return self.values.sum(axis=axis, dtype=dtype, keepdims=True)
+
+        def toarray(self):
+            raise AssertionError("non-winsorized bundle offsets must not densify sparse blocks")
+
+    class GuardedBackedMatrix:
+        def __getitem__(self, key):
+            rows, columns = key
+            assert columns == slice(None)
+            rows = np.asarray(rows, dtype=np.int64)
+            reads.append(rows.copy())
+            return SparseLikeBlock(counts[rows])
+
+    adata = SimpleNamespace(
+        n_obs=counts.shape[0],
+        obs=pd.DataFrame({"saved": np.linspace(-0.5, 0.5, counts.shape[0])}),
+        X=GuardedBackedMatrix(),
+    )
+    center = 2.5
+    offsets, provenance = cli_module._bundle_size_factors(
+        adata,
+        selected_row_indices=selected_rows,
+        size_factor_mode="observed",
+        size_factor_key=None,
+        library_size_key=None,
+        library_size_center_log_mean=center,
+        gene_clip_thresholds=None,
+        winsorize_gene_expression=False,
+    )
+
+    assert provenance == "analyzed_count_total"
+    np.testing.assert_array_equal(reads, [selected_rows])
+    np.testing.assert_allclose(
+        offsets,
+        (np.log1p(counts[selected_rows].sum(axis=1)) - center)[:, None],
+        rtol=1e-6,
+    )
+
+    saved, provenance = cli_module._bundle_size_factors(
+        adata,
+        selected_row_indices=selected_rows,
+        size_factor_mode="observed",
+        size_factor_key="saved",
+        library_size_key=None,
+        library_size_center_log_mean=None,
+        gene_clip_thresholds=None,
+        winsorize_gene_expression=False,
+    )
+    assert provenance == "obs_size_factor"
+    np.testing.assert_allclose(saved[:, 0], adata.obs["saved"].to_numpy()[selected_rows])
+
+
+def _write_guide_fixture(path, *, constant_depth: bool = False) -> None:
+    obs = pd.DataFrame(index=[f"c{i}" for i in range(6)])
+    counts = (
+        np.full((6, 2), 2, dtype=np.int32)
+        if constant_depth
+        else np.array([[2, 1], [2, 2], [1, 3], [2, 3], [1, 2], [1, 1]], dtype=np.int32)
+    )
+    rna = ad.AnnData(
+        counts,
+        obs=obs.copy(),
+        var=pd.DataFrame(index=["gene1", "gene2"]),
+    )
+    grna = ad.AnnData(
+        np.array(
+            [[1, 0, 0], [1, 0, 0], [0, 1, 0], [0, 1, 0], [0, 0, 1], [0, 0, 1]],
+            dtype=np.float32,
+        ),
+        obs=obs.copy(),
+        var=pd.DataFrame(index=["ctrl", "guide_a", "guide_b"]),
+    )
+    grna.varm["mapping"] = pd.DataFrame(
+        np.eye(3, dtype=np.float32),
+        index=grna.var_names,
+        columns=["ctrl", "element_a", "element_b"],
+    )
+    md.MuData({"rna": rna, "grna": grna}).write_h5mu(path)
+
+
+def _stub_cli_fits(monkeypatch, captured_size_factors: list[np.ndarray]) -> None:
+    def control_fit(data, **kwargs):
+        del kwargs
+        return api.ControlFit(
+            beta_0=jnp.zeros(2),
+            theta=jnp.ones(2),
+            noise_scale=jnp.ones(2),
+            factor_loadings=None,
+            factor_scores=None,
+            factor_center=None,
+            pca_loadings=None,
+            size_factors=data.size_factors,
+            losses=jnp.array([1.0]),
+            svi_result=None,
+        )
+
+    def beta_fit(data, control, **kwargs):
+        del control, kwargs
+        captured_size_factors.append(np.asarray(data.size_factors))
+        guide_names = list(data.guide_names or [])
+        guide_ids = np.asarray(
+            [["ctrl", "guide_a", "guide_b"].index(name) for name in guide_names],
+            dtype=np.float32,
+        )[:, None]
+        guide_values = np.broadcast_to(guide_ids + 0.1, (len(guide_names), 2)).copy()
+        relative = np.broadcast_to(guide_ids * 0.1 + 0.2, (len(guide_names), 2)).copy()
+        return api.BetaFit(
+            posterior_mean=jnp.full((len(data.pert_names), 2), 0.4),
+            posterior_scale=jnp.ones((len(data.pert_names), 2)),
+            z_values=jnp.full((len(data.pert_names), 2), 0.4),
+            losses=jnp.array([1.0]),
+            svi_result=None,
+            guide_effect_mean=jnp.asarray(guide_values),
+            guide_effect_scale=jnp.ones_like(jnp.asarray(guide_values)),
+            guide_effect_z_values=jnp.asarray(guide_values),
+            guide_relative_efficiency_mean=jnp.asarray(relative),
+            guide_relative_efficiency_scale=jnp.full_like(jnp.asarray(relative), 0.05),
+            guide_offset_mean=jnp.asarray(guide_values + 1.0),
+            guide_offset_scale=jnp.full_like(jnp.asarray(guide_values), 0.2),
+            guide_dispersion_excess_inverse=jnp.asarray(guide_values + 2.0),
+        )
+
+    monkeypatch.setattr(api, "fit_control", control_fit)
+    monkeypatch.setattr(api, "fit_perturbation_effects", beta_fit)
+    monkeypatch.setattr(api, "_save_loss_plot", lambda *args, **kwargs: None)
+    monkeypatch.setattr(api, "_save_multi_loss_plot", lambda *args, **kwargs: None)
+
+
+def test_chunked_cli_bundle_preserves_global_guide_arrays_and_derived_offsets(monkeypatch, tmp_path) -> None:
+    source = tmp_path / "input.h5mu"
+    out = tmp_path / "bundle"
+    _write_guide_fixture(source)
+    captured: list[np.ndarray] = []
+    _stub_cli_fits(monkeypatch, captured)
+
+    api.main(
+        [
+            "--input",
+            str(source),
+            "--out-dir",
+            str(out),
+            "--modality-key",
+            "rna",
+            "--perturbation-modality-key",
+            "grna",
+            "--perturbation-element-varm-key",
+            "mapping",
+            "--control-substring",
+            "ctrl",
+            "--guide-effect-strategy",
+            "relative",
+            "--perturbation-chunk-size",
+            "1",
+            "--no-crt",
+        ]
+    )
+
+    loaded = PerTurboModel.load(out)
+    assert loaded.beta_fit is not None
+    expected_guides = np.array([[0.1, 0.1], [1.1, 1.1], [2.1, 2.1]], dtype=np.float32)
+    np.testing.assert_allclose(loaded.beta_fit.guide_effect_mean, expected_guides)
+    np.testing.assert_allclose(loaded.beta_fit.guide_offset_mean, expected_guides + 1.0)
+    np.testing.assert_allclose(loaded.beta_fit.guide_dispersion_excess_inverse, expected_guides + 2.0)
+    np.testing.assert_allclose(loaded.guide_efficacy, [0.2, 0.3, 0.4])
+
+    fitted_offsets = np.concatenate(captured, axis=0)
+    simulated_offsets = _resolve_size_factors(loaded, np.arange(6), 1.0)
+    np.testing.assert_allclose(simulated_offsets, fitted_offsets)
+    metadata = json.loads((out / "metadata.json").read_text())
+    assert metadata["size_factor_mode"] == "observed"
+    assert metadata["size_factor_provenance"] == "analyzed_count_total"
+    assert metadata["size_factors_file"] == "size_factors.npy"
+
+
+def test_cli_bundle_keeps_explicit_none_offsets_zero(monkeypatch, tmp_path) -> None:
+    source = tmp_path / "input.h5mu"
+    out = tmp_path / "bundle"
+    _write_guide_fixture(source)
+    captured: list[np.ndarray] = []
+    _stub_cli_fits(monkeypatch, captured)
+
+    api.main(
+        [
+            "--input",
+            str(source),
+            "--out-dir",
+            str(out),
+            "--modality-key",
+            "rna",
+            "--perturbation-modality-key",
+            "grna",
+            "--perturbation-element-varm-key",
+            "mapping",
+            "--control-substring",
+            "ctrl",
+            "--guide-effect-strategy",
+            "relative",
+            "--size-factor-mode",
+            "none",
+            "--no-crt",
+        ]
+    )
+
+    loaded = PerTurboModel.load(out)
+    np.testing.assert_array_equal(captured[0], np.zeros((6, 1), dtype=np.float32))
+    np.testing.assert_array_equal(
+        _resolve_size_factors(loaded, np.arange(6), 1.0),
+        np.zeros((6, 1), dtype=np.float32),
+    )
+    metadata = json.loads((out / "metadata.json").read_text())
+    assert metadata["size_factor_mode"] == "none"
+    assert metadata["size_factor_provenance"] == "fixed_zero"
+
+
+def test_saved_constant_observed_offsets_are_not_rejected_as_raw_counts(monkeypatch, tmp_path) -> None:
+    source = tmp_path / "input.h5mu"
+    out = tmp_path / "bundle"
+    _write_guide_fixture(source, constant_depth=True)
+    captured: list[np.ndarray] = []
+    _stub_cli_fits(monkeypatch, captured)
+
+    api.main(
+        [
+            "--input",
+            str(source),
+            "--out-dir",
+            str(out),
+            "--modality-key",
+            "rna",
+            "--perturbation-modality-key",
+            "grna",
+            "--perturbation-element-varm-key",
+            "mapping",
+            "--control-substring",
+            "ctrl",
+            "--guide-effect-strategy",
+            "relative",
+            "--no-crt",
+        ]
+    )
+
+    loaded = PerTurboModel.load(out)
+    np.testing.assert_array_equal(
+        _resolve_size_factors(loaded, np.arange(6), 1.0),
+        np.zeros((6, 1), dtype=np.float32),
+    )
+
+
+def test_mixture_simulation_excludes_element_effect_from_outlier_mean(monkeypatch, tmp_path) -> None:
+    source = tmp_path / "input.h5mu"
+    _write_guide_fixture(source)
+    mdata = md.read_h5mu(source)
+    setup = MuDataSetup(
+        rna_modality="rna",
+        perturbation_modality="grna",
+        guide_by_element_key="mapping",
+        size_factor_mode="none",
+    )
+    model = PerTurboModel(mdata, setup=setup, likelihood="mixture_nb", effect_prior_dist="normal")
+    model.control_fit = api.ControlFit(
+        beta_0=jnp.array([1.0, 1.0]),
+        theta=jnp.ones(2),
+        noise_scale=jnp.ones(2),
+        factor_loadings=None,
+        factor_scores=None,
+        factor_center=None,
+        pca_loadings=None,
+        size_factors=jnp.zeros((6, 1)),
+        losses=jnp.array([]),
+        svi_result=None,
+        pi_outlier=jnp.ones(2),
+        theta_outlier=jnp.ones(2),
+        outlier_mean_shift=jnp.zeros(2),
+    )
+    model.beta_fit = api.BetaFit(
+        posterior_mean=jnp.zeros((3, 2)),
+        posterior_scale=jnp.ones((3, 2)),
+        z_values=jnp.zeros((3, 2)),
+        losses=jnp.array([]),
+        svi_result=None,
+    )
+    captured: dict[str, np.ndarray] = {}
+
+    def capture_counts(*, mu, outlier_mu, **kwargs):
+        del kwargs
+        captured["mu"] = np.asarray(mu)
+        captured["outlier_mu"] = np.asarray(outlier_mu)
+        return np.zeros_like(mu, dtype=np.int32)
+
+    monkeypatch.setattr(fitted_simulation, "_sample_counts", capture_counts)
+    fitted_simulation.simulate_data_from_trained_model(
+        model,
+        guide_obs=np.array([[1, 0, 0]], dtype=np.float32),
+        guide_by_element=np.eye(3, dtype=np.float32),
+        element_by_gene_lfc=np.array([[0.0, 2.0], [0.0, 0.0], [0.0, 0.0]], dtype=np.float32),
+        guide_efficacy=np.ones(3, dtype=np.float32),
+        cell_indices=np.array([0], dtype=np.int32),
+    )
+
+    np.testing.assert_allclose(captured["mu"], [[1.0, 3.0]])
+    np.testing.assert_allclose(captured["outlier_mu"], [[1.0, 1.0]])
+
+
+def test_shared_simulation_counts_duplicate_guides_once_with_unit_efficacy(monkeypatch, tmp_path) -> None:
+    source = tmp_path / "input.h5mu"
+    _write_guide_fixture(source)
+    model = PerTurboModel(
+        md.read_h5mu(source),
+        setup=MuDataSetup(
+            rna_modality="rna",
+            perturbation_modality="grna",
+            guide_by_element_key="mapping",
+            size_factor_mode="none",
+        ),
+        likelihood="negbin",
+        effect_prior_dist="normal",
+        guide_effect_strategy="shared",
+    )
+    model.control_fit = api.ControlFit(
+        beta_0=jnp.zeros(2),
+        theta=jnp.ones(2),
+        noise_scale=jnp.ones(2),
+        factor_loadings=None,
+        factor_scores=None,
+        factor_center=None,
+        pca_loadings=None,
+        size_factors=jnp.zeros((6, 1)),
+        losses=jnp.array([]),
+        svi_result=None,
+    )
+    model.beta_fit = api.BetaFit(
+        posterior_mean=jnp.zeros((2, 2)),
+        posterior_scale=jnp.ones((2, 2)),
+        z_values=jnp.zeros((2, 2)),
+        losses=jnp.array([]),
+        svi_result=None,
+    )
+    captured: list[np.ndarray] = []
+
+    def capture_counts(*, mu, **kwargs):
+        del kwargs
+        captured.append(np.asarray(mu))
+        return np.zeros_like(mu, dtype=np.int32)
+
+    monkeypatch.setattr(fitted_simulation, "_sample_counts", capture_counts)
+    common = {
+        "model": model,
+        "guide_obs": np.array([[0, 1, 1]], dtype=np.float32),
+        "guide_by_element": np.array([[0, 1], [1, 0], [1, 0]], dtype=np.float32),
+        "element_by_gene_lfc": np.array([[2.0, 0.0], [0.0, 0.0]], dtype=np.float32),
+        "cell_indices": np.array([0], dtype=np.int32),
+    }
+    fitted_simulation.simulate_data_from_trained_model(
+        **common,
+        guide_efficacy=np.ones(3, dtype=np.float32),
+    )
+    fitted_simulation.simulate_data_from_trained_model(
+        **common,
+        guide_efficacy=np.array([1.0, 0.5, 0.25], dtype=np.float32),
+    )
+
+    np.testing.assert_allclose(captured[0], [[2.0, 0.0]])
+    np.testing.assert_allclose(captured[1], [[1.5, 0.0]])

--- a/tests/test_score_resampling.py
+++ b/tests/test_score_resampling.py
@@ -545,7 +545,12 @@ def test_precomputed_permutations_reproduce_the_inline_draws() -> None:
     np.testing.assert_array_equal(np.asarray(inline.p_value), np.asarray(reused.p_value))
 
 
-def _design_over_targets(keep_targets: tuple[int, ...], *, seed: int = 5) -> tuple[object, np.ndarray]:
+def _design_over_targets(
+    keep_targets: tuple[int, ...],
+    *,
+    seed: int = 5,
+    shifted_targets: tuple[int, ...] = (),
+) -> tuple[object, np.ndarray]:
     """Controls plus a chosen subset of targets, laid out as a chunk would be.
 
     Perturbation chunking hands each chunk only its own targets' cells, so a
@@ -562,6 +567,9 @@ def _design_over_targets(keep_targets: tuple[int, ...], *, seed: int = 5) -> tup
     theta = np.asarray([3.0, 9.0, 20.0])
     n_genes = theta.size
     offset = rng.normal(scale=0.2, size=labels.size)
+    covariate = rng.normal(size=labels.size)
+    for target in shifted_targets:
+        covariate[labels == target + 1] += 3.0
     eta = offset[:, None] + 1.5
     counts = rng.negative_binomial(theta[None, :], theta[None, :] / (theta[None, :] + np.exp(eta)))
     strata = np.tile(np.asarray([0, 1]), labels.size // 2)
@@ -579,6 +587,8 @@ def _design_over_targets(keep_targets: tuple[int, ...], *, seed: int = 5) -> tup
         pert_names=["NTC", *[f"target_{index}" for index in keep_targets]],
         gene_names=[f"gene_{index}" for index in range(n_genes)],
         size_factors=jnp.asarray(offset[keep_cells, None]),
+        covariates=jnp.asarray(covariate[keep_cells, None]),
+        covariate_names=["selection_covariate"],
     )
     design = prepare_joint_nb_design(data, control_perturbations=["NTC"], dispersion=theta)
     return design, strata[keep_cells]
@@ -602,6 +612,73 @@ def test_a_targets_resamples_do_not_depend_on_which_targets_share_its_run() -> N
     assert full.target_names == ("target_0", "target_1", "target_2")
     assert chunk.target_names == ("target_2",)
     np.testing.assert_array_equal(full_draws.indices[2], chunk_draws.indices[0])
+
+
+def test_propensity_fit_and_tail_ignore_unrelated_shifted_targets() -> None:
+    """Each target's model is fitted on controls plus only its own cells.
+
+    Moving unrelated targets far along the propensity covariate therefore
+    cannot alter target_2's pool logits or deterministic saddlepoint tail when
+    target_2 moves from a multi-target chunk into a chunk by itself.
+    """
+
+    full, _ = _design_over_targets((0, 1, 2), shifted_targets=(0, 1))
+    chunk, _ = _design_over_targets((2,))
+    full_propensity = precompute_low_moi_permutations(
+        full,
+        num_resamples=8,
+        seed=19,
+        resampling_mechanism="propensity",
+        draw_resamples=True,
+    )
+    chunk_propensity = precompute_low_moi_permutations(
+        chunk,
+        num_resamples=8,
+        seed=19,
+        resampling_mechanism="propensity",
+        draw_resamples=True,
+    )
+    np.testing.assert_allclose(
+        full_propensity.pool_logits[2], chunk_propensity.pool_logits[0], rtol=2e-5, atol=2e-5
+    )
+    np.testing.assert_array_equal(full_propensity.indices[2], chunk_propensity.indices[0])
+
+    full_saddlepoint = precompute_low_moi_permutations(
+        full,
+        num_resamples=8,
+        seed=19,
+        resampling_mechanism="propensity",
+        draw_resamples=False,
+    )
+    chunk_saddlepoint = precompute_low_moi_permutations(
+        chunk,
+        num_resamples=8,
+        seed=19,
+        resampling_mechanism="propensity",
+        draw_resamples=False,
+    )
+
+    common = dict(
+        num_resamples=8,
+        seed=19,
+        backend="jax",
+        null_model="control_only",
+        tail_approximation="saddlepoint",
+        saddlepoint_only=True,
+        saddlepoint_screen_p_value=1.0,
+    )
+    full_result = run_low_moi_score_permutations(
+        full, permutations=full_saddlepoint, **common
+    )
+    chunk_result = run_low_moi_score_permutations(
+        chunk, permutations=chunk_saddlepoint, **common
+    )
+    np.testing.assert_allclose(
+        np.asarray(full_result.tail_fits["saddlepoint"]["log_p_value"])[2],
+        np.asarray(chunk_result.tail_fits["saddlepoint"]["log_p_value"])[0],
+        rtol=2e-5,
+        atol=2e-7,
+    )
 
 
 def test_distinct_targets_still_get_distinct_resamples() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -3433,7 +3433,7 @@ dev = [
     { name = "build", specifier = ">=1.2" },
     { name = "pre-commit", specifier = ">=4.0" },
     { name = "ruff", specifier = ">=0.8" },
-    { name = "twine", specifier = ">=6.0" },
+    { name = "twine", specifier = ">=7.0" },
 ]
 test = [
     { name = "coverage", extras = ["toml"], specifier = ">=7.6" },
@@ -5555,7 +5555,7 @@ wheels = [
 
 [[package]]
 name = "twine"
-version = "6.2.0"
+version = "7.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "id" },
@@ -5569,9 +5569,9 @@ dependencies = [
     { name = "rich" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e0/a8/949edebe3a82774c1ec34f637f5dd82d1cf22c25e963b7d63771083bbee5/twine-6.2.0.tar.gz", hash = "sha256:e5ed0d2fd70c9959770dce51c8f39c8945c574e18173a7b81802dab51b4b75cf", size = 172262 }
+sdist = { url = "https://files.pythonhosted.org/packages/92/3c/58f808a359700f39a967dffede33efeac809262c03303fa3eec6afff8f49/twine-7.0.0.tar.gz", hash = "sha256:85cdb29c518efef867360ae4acd4b0dfd61c8654a22fca08e6f8539f05022177", size = 215032 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/7a/882d99539b19b1490cac5d77c67338d126e4122c8276bf640e411650c830/twine-6.2.0-py3-none-any.whl", hash = "sha256:418ebf08ccda9a8caaebe414433b0ba5e25eb5e4a927667122fbe8f829f985d8", size = 42727 },
+    { url = "https://files.pythonhosted.org/packages/96/08/ddcdc06225eaad6de0e48e1002b06d919dbde20582d0662c7af51308e5d6/twine-7.0.0-py3-none-any.whl", hash = "sha256:b854164df26db268af05f49aa5c0344b10e27a494343ff05b1e0bad3b135f5a7", size = 43204 },
 ]
 
 [[package]]


### PR DESCRIPTION
Chunking co-occurring perturbations can omit active predictors and attribute their effects to the remaining targets. This change preserves the joint model with gene blocks, while retaining efficient perturbation chunks for mutually exclusive low-MOI designs. It also removes chunk-dependent propensity fits and bounds several large count/design allocations.

### Changes

- Add `--gene-chunk-size` and automatic gene blocking when perturbation chunks would split co-occurring predictors. Retain sparse assignments and use indexed designs for cell minibatches; reject partial target loads that omit active effects.
- Stream backed count reads and library totals without loading unused AnnData layers or `.raw`. Block Newton diagnostics by gene and cache all-cells propensity fits across gene blocks.
- Use rank-revealing propensity designs, target-specific low-MOI populations, stable target random keys, and one global BH correction after collecting both chunk axes.
- Preserve guide posterior fields and fitted offsets in saved bundles; correct shared-element simulation, mixture-NB means, and log-normal NB quadrature/sample shapes.
- Update CLI/documentation for chunking, convergence, and approximate tail probabilities. Enable release checks on `v2-port` and update Twine for current package metadata.

Rebased onto `c609abf` (2.0.0rc5), retaining the latest version and sparse grouping changes.

### Validation

- Full suite: **389 passed** before the final bounded-read fixes and rc5 rebase.
- Final bounded-memory integration checks: **47 passed**; affected integration tests after the rc5 rebase: **51 passed**, including the upstream 60,000-cell sparse grouping regression.
- rc5 wheel and source distribution build and strict Twine checks pass. Isolated wheel import, focused Ruff, and diff whitespace checks pass.
- Real Replogle RPE-1 debug subset: 780 cells × 128 genes, six targets plus controls, preserving original full-panel library totals; JAX CPU backend.

| Run | Wall time | Peak process RSS |
| --- | ---: | ---: |
| Effects + CRT, 500 steps per stage, target chunks of two | 30.80 s | 1.12 GiB |
| CRT only, 500 control steps, 64-gene blocks | 25.65 s | 0.86 GiB |
| Effects + CRT, 2,500 steps per stage, target chunks of two | 43.35 s | 0.97 GiB |

All 768 target-gene CRT pairs were valid; corresponding gene- and target-chunked p/q-values agreed within 3.4e-6. Strong Bayesian effects still depended on training budget (MRPL36: −2.265 at 500 steps versus −2.811 at 2,500), so 500 steps should not be treated as a convergence guarantee.

### Limits and follow-up

This subset validates execution and memory use, not p-value calibration or full-screen throughput. CUDA/MGH benchmarks, far-tail negative-control calibration, and strong-effect convergence remain cluster validation work. Gene blocking currently supports plain NB with fixed observed/zero offsets and shared always-on effects, without latent factors, guide random effects, extra dispersion, or baseline uncertainty. Control fitting and final perturbation × gene output tables still impose host-memory costs. Mirror these changes into Cortado2 before future ports.
